### PR TITLE
Fix MKRF Patchworks map layer presentation

### DIFF
--- a/docs/operator-runbook.rst
+++ b/docs/operator-runbook.rst
@@ -120,6 +120,20 @@ This redesign is the intended behavior for the next MKRF prerelease line
 after ``v0.0.2a1``. The older legacy/PoC proportional split and broader
 pre-cedar-pole CT age family are retained only as benchmark/reference context.
 
+Canonical GUI map layers
+------------------------
+
+When launching the canonical ``base.pin`` in the Patchworks GUI, the default
+map layer stack includes:
+
+- ``Forest Outline`` as a muted gray, semi-transparent model-extent context
+  layer;
+- ``Age Class (20-year)`` as a hidden-by-default dynamic mean-fragment-age
+  layer using ``0.5 * (MANAGEDOFFSET + UNMANAGEDOFFSET)``; and
+- ``Current Treatments`` / ``Latest Treatments`` themes whose legend entries
+  use the active treatment labels such as ``CC``, ``CT35``, ``CT40``, and
+  ``CT45``.
+
 What the current ``v0`` smoke proves
 ------------------------------------
 

--- a/docs/treatments-and-state-logic.rst
+++ b/docs/treatments-and-state-logic.rst
@@ -208,9 +208,14 @@ Current GUI Treatment Layers
 
 The canonical ``base.pin`` now includes GUI map layers for:
 
-- default blocks;
-- current treatments via ``CURRENTTREATMENT``; and
-- latest treatments via ``LASTTREATMENT``.
+- ``Forest Outline``, a neutral gray, semi-transparent model-extent context
+  layer;
+- ``Age Class (20-year)``, a hidden-by-default dynamic mean-fragment-age
+  theme using ``0.5 * (MANAGEDOFFSET + UNMANAGEDOFFSET)`` with 20-year bins;
+- current treatments via ``CURRENTTREATMENT``, with legend entries that match
+  the active treatment labels; and
+- latest treatments via ``LASTTREATMENT``, with legend entries that match the
+  active treatment labels.
 
 It also includes guarded patch themes when patch displays are enabled.
 

--- a/models/mkrf_patchworks_model/analysis/base.pin
+++ b/models/mkrf_patchworks_model/analysis/base.pin
@@ -45,10 +45,97 @@ int PatchWorks_Init() {
 
       DefaultTheme def = new DefaultTheme(
          blockData,
-         new PolygonSymbol(new Color(204, 204, 255))
+         new PolygonSymbol(new Color(128, 128, 128, 128))
       );
+      def.setCaption("Forest Outline");
       Layer defLayer = new GeoRelLayer(blockData, def);
       layers.add(defLayer);
+
+      NumericTheme ageClassTheme = new NumericTheme(blockData);
+      ageClassTheme.setFieldname("0.5 * (MANAGEDOFFSET + UNMANAGEDOFFSET)");
+      ageClassTheme.addElement(
+         new ThemeElement(
+            "age_000_019",
+            PolygonSymbol.getDefault(Symbol.FILL, Symbol.APPLE, 0)
+         ),
+         "0 - 19"
+      );
+      ageClassTheme.addElement(
+         new ThemeElement(
+            "age_020_039",
+            PolygonSymbol.getDefault(Symbol.FILL, Symbol.APPLE, 1)
+         ),
+         "20 - 39"
+      );
+      ageClassTheme.addElement(
+         new ThemeElement(
+            "age_040_059",
+            PolygonSymbol.getDefault(Symbol.FILL, Symbol.APPLE, 2)
+         ),
+         "40 - 59"
+      );
+      ageClassTheme.addElement(
+         new ThemeElement(
+            "age_060_079",
+            PolygonSymbol.getDefault(Symbol.FILL, Symbol.APPLE, 3)
+         ),
+         "60 - 79"
+      );
+      ageClassTheme.addElement(
+         new ThemeElement(
+            "age_080_099",
+            PolygonSymbol.getDefault(Symbol.FILL, Symbol.APPLE, 4)
+         ),
+         "80 - 99"
+      );
+      ageClassTheme.addElement(
+         new ThemeElement(
+            "age_100_119",
+            PolygonSymbol.getDefault(Symbol.FILL, Symbol.APPLE, 5)
+         ),
+         "100 - 119"
+      );
+      ageClassTheme.addElement(
+         new ThemeElement(
+            "age_120_139",
+            PolygonSymbol.getDefault(Symbol.FILL, Symbol.APPLE, 6)
+         ),
+         "120 - 139"
+      );
+      ageClassTheme.addElement(
+         new ThemeElement(
+            "age_140_159",
+            PolygonSymbol.getDefault(Symbol.FILL, Symbol.APPLE, 7)
+         ),
+         "140 - 159"
+      );
+      ageClassTheme.addElement(
+         new ThemeElement(
+            "age_160_179",
+            PolygonSymbol.getDefault(Symbol.FILL, Symbol.APPLE, 8)
+         ),
+         "160 - 179"
+      );
+      ageClassTheme.addElement(
+         new ThemeElement(
+            "age_180_199",
+            PolygonSymbol.getDefault(Symbol.FILL, Symbol.APPLE, 9)
+         ),
+         "180 - 199"
+      );
+      ageClassTheme.addElement(
+         new ThemeElement(
+            "age_200plus",
+            PolygonSymbol.getDefault(Symbol.FILL, Symbol.APPLE, 10)
+         ),
+         "200 - 99999"
+      );
+      ageClassTheme.setCaption("Age Class (20-year)");
+      ageClassTheme.setUnclassified(new ThemeElement("", PolygonSymbol.erase));
+      blockData.addTheme(ageClassTheme);
+      GeoRelLayer ageClassLayer = new GeoRelLayer(blockData, ageClassTheme);
+      ageClassLayer.setVisible(false);
+      layers.add(ageClassLayer);
 
       UniqueValueTheme currTreatTheme = new UniqueValueTheme(blockData);
       currTreatTheme.setFieldname("CURRENTTREATMENT");
@@ -61,10 +148,24 @@ int PatchWorks_Init() {
       );
       currTreatTheme.addElement(
          new ThemeElement(
-            "CT",
+            "CT35",
             PolygonSymbol.getDefault(Symbol.FILL, Symbol.GEMS, 1)
          ),
-         "CT"
+         "CT35"
+      );
+      currTreatTheme.addElement(
+         new ThemeElement(
+            "CT40",
+            PolygonSymbol.getDefault(Symbol.FILL, Symbol.GEMS, 2)
+         ),
+         "CT40"
+      );
+      currTreatTheme.addElement(
+         new ThemeElement(
+            "CT45",
+            PolygonSymbol.getDefault(Symbol.FILL, Symbol.GEMS, 3)
+         ),
+         "CT45"
       );
       currTreatTheme.setCaption("Current Treatments");
       currTreatTheme.setUnclassified(new ThemeElement("", PolygonSymbol.erase));
@@ -84,10 +185,24 @@ int PatchWorks_Init() {
       );
       latestTreatTheme.addElement(
          new ThemeElement(
-            "CT",
+            "CT35",
             PolygonSymbol.getDefault(Symbol.FILL, Symbol.GEMS, 1)
          ),
-         "CT"
+         "CT35"
+      );
+      latestTreatTheme.addElement(
+         new ThemeElement(
+            "CT40",
+            PolygonSymbol.getDefault(Symbol.FILL, Symbol.GEMS, 2)
+         ),
+         "CT40"
+      );
+      latestTreatTheme.addElement(
+         new ThemeElement(
+            "CT45",
+            PolygonSymbol.getDefault(Symbol.FILL, Symbol.GEMS, 3)
+         ),
+         "CT45"
       );
       latestTreatTheme.setCaption("Latest Treatments");
       latestTreatTheme.setUnclassified(new ThemeElement("", PolygonSymbol.erase));


### PR DESCRIPTION
## Summary
- rename and restyle the default Patchworks block layer as `Forest Outline` using semi-transparent gray symbology
- add a hidden-by-default `Age Class (20-year)` layer driven by dynamic mean fragment age: `0.5 * (MANAGEDOFFSET + UNMANAGEDOFFSET)`
- update current/latest treatment legends to use active treatment labels: `CC`, `CT35`, `CT40`, `CT45`
- document the canonical GUI layer stack in the operator runbook and treatment/state logic docs

## QA
- regenerated runtime package: `femic instance mkrf-init-runtime-package --instance-root external\femic-mkrf-instance`
- targeted pytest: `45 passed`
- Patchworks preflight: passed against `config/patchworks.runtime.mkrf_rebuild.windows.yaml`
- Patchworks smoke: `mkrf_map_layers_smoke_20260606b`, return code `0`
- saved-stage sanity audit: `24` rows, `0` failures
- docs build: Sphinx HTML build passed
- `git diff --check`: clean apart from normal Windows line-ending warnings

Refs #21