### PR TITLE
Refine MKRF map layer symbology

### DIFF
--- a/docs/operator-runbook.rst
+++ b/docs/operator-runbook.rst
@@ -126,10 +126,11 @@ Canonical GUI map layers
 When launching the canonical ``base.pin`` in the Patchworks GUI, the default
 map layer stack includes:
 
-- ``Forest Outline`` as a muted gray, semi-transparent model-extent context
+- ``Forest Outline`` as a very light gray model-extent context
   layer;
 - ``Age Class (20-year)`` as a hidden-by-default dynamic mean-fragment-age
-  layer using ``0.5 * (MANAGEDOFFSET + UNMANAGEDOFFSET)``; and
+  layer using ``0.5 * (MANAGEDOFFSET + UNMANAGEDOFFSET)`` and a yellow-green
+  graduated color ramp; and
 - ``Current Treatments`` / ``Latest Treatments`` themes whose legend entries
   use the active treatment labels such as ``CC``, ``CT35``, ``CT40``, and
   ``CT45``.

--- a/docs/treatments-and-state-logic.rst
+++ b/docs/treatments-and-state-logic.rst
@@ -208,10 +208,11 @@ Current GUI Treatment Layers
 
 The canonical ``base.pin`` now includes GUI map layers for:
 
-- ``Forest Outline``, a neutral gray, semi-transparent model-extent context
+- ``Forest Outline``, a very light gray model-extent context
   layer;
 - ``Age Class (20-year)``, a hidden-by-default dynamic mean-fragment-age
-  theme using ``0.5 * (MANAGEDOFFSET + UNMANAGEDOFFSET)`` with 20-year bins;
+  theme using ``0.5 * (MANAGEDOFFSET + UNMANAGEDOFFSET)`` with 20-year bins
+  and a yellow-green graduated color ramp;
 - current treatments via ``CURRENTTREATMENT``, with legend entries that match
   the active treatment labels; and
 - latest treatments via ``LASTTREATMENT``, with legend entries that match the

--- a/models/mkrf_patchworks_model/analysis/base.pin
+++ b/models/mkrf_patchworks_model/analysis/base.pin
@@ -45,7 +45,7 @@ int PatchWorks_Init() {
 
       DefaultTheme def = new DefaultTheme(
          blockData,
-         new PolygonSymbol(new Color(128, 128, 128, 128))
+         new PolygonSymbol(new Color(239, 239, 239))
       );
       def.setCaption("Forest Outline");
       Layer defLayer = new GeoRelLayer(blockData, def);
@@ -56,77 +56,77 @@ int PatchWorks_Init() {
       ageClassTheme.addElement(
          new ThemeElement(
             "age_000_019",
-            PolygonSymbol.getDefault(Symbol.FILL, Symbol.APPLE, 0)
+            new PolygonSymbol(new Color(255, 255, 229))
          ),
          "0 - 19"
       );
       ageClassTheme.addElement(
          new ThemeElement(
             "age_020_039",
-            PolygonSymbol.getDefault(Symbol.FILL, Symbol.APPLE, 1)
+            new PolygonSymbol(new Color(248, 252, 193))
          ),
          "20 - 39"
       );
       ageClassTheme.addElement(
          new ThemeElement(
             "age_040_059",
-            PolygonSymbol.getDefault(Symbol.FILL, Symbol.APPLE, 2)
+            new PolygonSymbol(new Color(229, 244, 171))
          ),
          "40 - 59"
       );
       ageClassTheme.addElement(
          new ThemeElement(
             "age_060_079",
-            PolygonSymbol.getDefault(Symbol.FILL, Symbol.APPLE, 3)
+            new PolygonSymbol(new Color(199, 232, 154))
          ),
          "60 - 79"
       );
       ageClassTheme.addElement(
          new ThemeElement(
             "age_080_099",
-            PolygonSymbol.getDefault(Symbol.FILL, Symbol.APPLE, 4)
+            new PolygonSymbol(new Color(162, 216, 137))
          ),
          "80 - 99"
       );
       ageClassTheme.addElement(
          new ThemeElement(
             "age_100_119",
-            PolygonSymbol.getDefault(Symbol.FILL, Symbol.APPLE, 5)
+            new PolygonSymbol(new Color(120, 198, 121))
          ),
          "100 - 119"
       );
       ageClassTheme.addElement(
          new ThemeElement(
             "age_120_139",
-            PolygonSymbol.getDefault(Symbol.FILL, Symbol.APPLE, 6)
+            new PolygonSymbol(new Color(76, 176, 98))
          ),
          "120 - 139"
       );
       ageClassTheme.addElement(
          new ThemeElement(
             "age_140_159",
-            PolygonSymbol.getDefault(Symbol.FILL, Symbol.APPLE, 7)
+            new PolygonSymbol(new Color(47, 147, 77))
          ),
          "140 - 159"
       );
       ageClassTheme.addElement(
          new ThemeElement(
             "age_160_179",
-            PolygonSymbol.getDefault(Symbol.FILL, Symbol.APPLE, 8)
+            new PolygonSymbol(new Color(20, 120, 62))
          ),
          "160 - 179"
       );
       ageClassTheme.addElement(
          new ThemeElement(
             "age_180_199",
-            PolygonSymbol.getDefault(Symbol.FILL, Symbol.APPLE, 9)
+            new PolygonSymbol(new Color(0, 97, 52))
          ),
          "180 - 199"
       );
       ageClassTheme.addElement(
          new ThemeElement(
             "age_200plus",
-            PolygonSymbol.getDefault(Symbol.FILL, Symbol.APPLE, 10)
+            new PolygonSymbol(new Color(0, 69, 41))
          ),
          "200 - 99999"
       );


### PR DESCRIPTION
## Summary
- switch `Forest Outline` from alpha transparency to solid very-light-gray paint (`239,239,239`) to avoid Patchworks renderer issues
- give `Age Class (20-year)` explicit graduated YlGn-style symbols while keeping clean 20-year bins
- keep age class dynamic on `0.5 * (MANAGEDOFFSET + UNMANAGEDOFFSET)`
- update operator docs for the final layer presentation

## QA
- regenerated canonical runtime package
- targeted pytest: `45 passed`
- Patchworks preflight passed
- Patchworks smoke passed: `mkrf_map_layers_ramp_outline_smoke_20260606`, return code `0`
- saved-stage sanity audit: `24` rows, `0` failures
- instance Sphinx docs build passed
- `git diff --check`: clean apart from normal Windows line-ending warnings

Refs #21