### PR TITLE
Add FreshForge MKRF rebuild workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,29 @@ Current primary runtime/package references:
 - retained PoC benchmark package:
   `models/mkrf_patchworks_model_poc/`
 
+## FreshForge Workflow Contract
+
+This instance owns the concrete FreshForge workflow document for the MKRF
+canonical rebuild lane:
+
+- `workflows/freshforge/mkrf_model_build_workflow.yaml`
+
+FreshForge is a declarative planning and validation surface here. It can list
+the FEMIC provider, validate the MKRF graph, inspect provider references, and
+produce a deterministic non-executing plan:
+
+```bash
+freshforge providers
+freshforge validate workflows/freshforge/mkrf_model_build_workflow.yaml
+freshforge inspect workflows/freshforge/mkrf_model_build_workflow.yaml
+freshforge plan workflows/freshforge/mkrf_model_build_workflow.yaml
+```
+
+FreshForge does not execute FEMIC stages, launch BTC, launch Patchworks,
+materialize DataLad content, or inspect declared artifact files. Use
+`config/rebuild.spec.yaml` and `femic instance rebuild` for execution and
+rebuild dry-runs.
+
 ## Project Communication Surfaces
 
 High-level MKRF project planning and team communication also lives in Basecamp.

--- a/docs/operator-runbook.rst
+++ b/docs/operator-runbook.rst
@@ -4,21 +4,31 @@ Operator Runbook
 Minimal Operator Path
 ---------------------
 
-1. Validate the instance spec:
+1. Validate and plan the FreshForge workflow graph:
+
+   - ``freshforge providers``
+   - ``freshforge validate workflows/freshforge/mkrf_model_build_workflow.yaml``
+   - ``freshforge inspect workflows/freshforge/mkrf_model_build_workflow.yaml``
+   - ``freshforge plan workflows/freshforge/mkrf_model_build_workflow.yaml``
+
+   This is a non-executing graph contract. It does not run FEMIC, BTC,
+   Patchworks, DataLad, or artifact inspection.
+
+2. Validate the instance spec:
 
    - ``femic instance validate-spec --spec config/rebuild.spec.yaml``
 
-2. Review the current runtime wiring:
+3. Review the current runtime wiring:
 
    - ``config/patchworks.runtime.mkrf_rebuild.windows.yaml``
 
-3. Inspect or launch the canonical runtime package from:
+4. Inspect or launch the canonical runtime package from:
 
    - runtime XML: ``models/mkrf_patchworks_model/xml/forestmodel.xml``
    - runtime tracks: ``models/mkrf_patchworks_model/tracks/``
    - runtime spatial: ``models/mkrf_patchworks_model/spatial/``
 
-4. Use the canonical package for:
+5. Use the canonical package for:
 
    - current runtime/package inspection;
    - Matrix Builder rebuild validation; and
@@ -29,7 +39,7 @@ Minimal Operator Path
    - :doc:`treatments-and-state-logic`
    - :doc:`analysis-units-and-yield-curves`
 
-5. For canonical scenario smoke validation, use the canonical base lane and do
+6. For canonical scenario smoke validation, use the canonical base lane and do
    not rely on very short scheduler samples:
 
    - ``femic patchworks run-default-scenario mkrf.base``
@@ -38,11 +48,11 @@ Minimal Operator Path
    ``100000`` iterations because shorter samples were not stable enough for
    meaningful runtime validation.
 
-6. After a canonical smoke run, audit the saved stage directly:
+7. After a canonical smoke run, audit the saved stage directly:
 
    - ``femic instance mkrf-audit-runtime-sanity --instance-root . --stage-dir runtime/logs/headless_stage/<run-id>``
 
-5. Use the retained PoC package only for benchmark/reference comparison:
+8. Use the retained PoC package only for benchmark/reference comparison:
 
    - ``models/mkrf_patchworks_model_poc/analysis/base.pin``
    - ``models/mkrf_patchworks_model_poc/analysis/initialTargetSummary.csv``

--- a/docs/rebuild-and-qa.rst
+++ b/docs/rebuild-and-qa.rst
@@ -20,6 +20,9 @@ Core Validation Surfaces
 ------------------------
 
 - ``femic instance validate-spec --spec config/rebuild.spec.yaml``
+- ``freshforge validate workflows/freshforge/mkrf_model_build_workflow.yaml``
+- ``freshforge inspect workflows/freshforge/mkrf_model_build_workflow.yaml``
+- ``freshforge plan workflows/freshforge/mkrf_model_build_workflow.yaml``
 - runtime XML under ``models/mkrf_patchworks_model/xml/``
 - runtime tracks under ``models/mkrf_patchworks_model/tracks/``
 - runtime spatial under ``models/mkrf_patchworks_model/spatial/``
@@ -32,7 +35,7 @@ High-Signal QA Logic
 
 The accepted QA stack for the canonical lane is:
 
-1. validate the instance spec and runtime wiring;
+1. validate the FreshForge graph, instance spec, and runtime wiring;
 2. regenerate the canonical XML/package surfaces from rebuild-owned inputs;
 3. rebuild tracks through Matrix Builder;
 4. inspect the rebuilt features/products/accounts directly; and
@@ -43,6 +46,20 @@ The accepted QA stack for the canonical lane is:
 
 The retained PoC benchmark lane still matters as comparison evidence, but it is
 not the primary runtime/package acceptance lane anymore.
+
+FreshForge Planning Boundary
+----------------------------
+
+The FreshForge workflow at
+``workflows/freshforge/mkrf_model_build_workflow.yaml`` is the declarative
+contract for the MKRF rebuild graph. It records the validate-case through
+matrix-build order, FEMIC provider references, MKRF-owned configuration paths,
+and declared runtime artifacts.
+
+FreshForge validation and planning are non-executing. They do not run FEMIC
+commands, launch BTC or Patchworks, materialize DataLad content, or read
+declared artifact files. The execution surface remains
+``femic instance rebuild`` with ``config/rebuild.spec.yaml``.
 
 Benchmark Acceptance Reading
 ----------------------------

--- a/runbooks/REBUILD_RUNBOOK.md
+++ b/runbooks/REBUILD_RUNBOOK.md
@@ -14,6 +14,24 @@ companion to that docs surface, not as a replacement for it.
 1. `femic instance validate-spec --spec config/rebuild.spec.yaml`
 2. `femic instance rebuild --spec config/rebuild.spec.yaml --dry-run --run-id mkrf_dryrun`
 
+## FreshForge planning checks
+
+The instance-owned FreshForge graph is:
+
+- `workflows/freshforge/mkrf_model_build_workflow.yaml`
+
+Use it to validate, inspect, and plan the rebuild graph before execution:
+
+1. `freshforge providers`
+2. `freshforge validate workflows/freshforge/mkrf_model_build_workflow.yaml`
+3. `freshforge inspect workflows/freshforge/mkrf_model_build_workflow.yaml`
+4. `freshforge plan workflows/freshforge/mkrf_model_build_workflow.yaml`
+
+FreshForge is non-executing in this phase. It does not run FEMIC commands,
+launch BTC, launch Patchworks, materialize DataLad content, or inspect declared
+artifact files. Execution remains governed by `config/rebuild.spec.yaml` and
+`femic instance rebuild`.
+
 ## Current scope boundary
 
 1. The real MKRF bulky data/model payload is not published in this slice.

--- a/workflows/freshforge/mkrf_model_build_workflow.yaml
+++ b/workflows/freshforge/mkrf_model_build_workflow.yaml
@@ -1,0 +1,93 @@
+workflow:
+  id: mkrf_model_build
+  name: MKRF FEMIC model-build workflow
+  description: Plan-only FreshForge graph for the MKRF canonical rebuild lane.
+nodes:
+  - id: validate_case
+    provider: femic.validate_case
+    outputs:
+      case_validation: case_preflight_ok
+    parameters:
+      instance_root: .
+      run_config: config/run_profile.mkrf.yaml
+  - id: geospatial_preflight
+    provider: femic.geospatial_preflight
+    needs:
+      - validate_case
+    inputs:
+      case_validation: validate_case.case_validation
+    outputs:
+      geospatial_runtime: geospatial_runtime_ok
+    parameters:
+      instance_root: .
+  - id: compile_upstream
+    provider: femic.compile_upstream
+    needs:
+      - geospatial_preflight
+    inputs:
+      geospatial_runtime: geospatial_preflight.geospatial_runtime
+    outputs:
+      btc_handoff: stage01a_btc_handoff
+    parameters:
+      instance_root: .
+      run_config: config/run_profile.mkrf.yaml
+      run_id: mkrf_freshforge_plan
+    artifacts:
+      run_manifest: runtime/logs/run_manifest-mkrf_freshforge_plan.json
+  - id: btc_post_tipsy
+    provider: femic.btc_post_tipsy
+    needs:
+      - compile_upstream
+    inputs:
+      btc_handoff: compile_upstream.btc_handoff
+    outputs:
+      model_input_bundle: data/model_input_bundle
+    parameters:
+      instance_root: .
+      run_config: config/run_profile.mkrf.yaml
+      tsa: mkrf
+      run_id: mkrf_freshforge_plan
+    artifacts:
+      btc_manifest: runtime/logs/btc_manifest-mkrf_freshforge_plan.json
+      post_tipsy_manifest: runtime/logs/run_manifest-post_tipsy_mkrf_freshforge_plan.json
+  - id: export_patchworks
+    provider: femic.export_patchworks
+    needs:
+      - btc_post_tipsy
+    inputs:
+      model_input_bundle: btc_post_tipsy.model_input_bundle
+    outputs:
+      patchworks_package: models/mkrf_patchworks_model
+    parameters:
+      instance_root: .
+      run_config: config/run_profile.mkrf.yaml
+      tsa: mkrf
+    artifacts:
+      forestmodel_xml: models/mkrf_patchworks_model/xml/forestmodel.xml
+      fragments: models/mkrf_patchworks_model/spatial/fragments.dbf
+      tracks: models/mkrf_patchworks_model/tracks
+  - id: patchworks_preflight
+    provider: femic.patchworks_preflight
+    needs:
+      - export_patchworks
+    inputs:
+      patchworks_package: export_patchworks.patchworks_package
+    outputs:
+      patchworks_runtime: patchworks_runtime_ok
+    parameters:
+      instance_root: .
+      patchworks_config: config/patchworks.runtime.mkrf_rebuild.windows.yaml
+  - id: matrix_build
+    provider: femic.matrix_build
+    needs:
+      - patchworks_preflight
+    inputs:
+      patchworks_runtime: patchworks_preflight.patchworks_runtime
+    outputs:
+      compiled_patchworks_model: models/mkrf_patchworks_model/tracks
+    parameters:
+      instance_root: .
+      patchworks_config: config/patchworks.runtime.mkrf_rebuild.windows.yaml
+      run_id: mkrf_freshforge_plan
+    artifacts:
+      matrix_build_manifest: runtime/logs/patchworks_matrixbuilder_manifest-mkrf_freshforge_plan.json


### PR DESCRIPTION
## Summary
- Add the instance-owned FreshForge workflow contract for the MKRF canonical rebuild lane.
- Document FreshForge provider discovery, validate, inspect, and plan commands in README/docs/runbook surfaces.
- Preserve the boundary that FreshForge is non-executing and `femic instance rebuild` remains the execution surface.

## Validation
Passed from `external/femic-mkrf-instance` using the parent FEMIC virtualenv:
- `freshforge providers --json`
- `freshforge validate workflows/freshforge/mkrf_model_build_workflow.yaml --json`
- `freshforge inspect workflows/freshforge/mkrf_model_build_workflow.yaml --json`
- `freshforge plan workflows/freshforge/mkrf_model_build_workflow.yaml --json`
- `femic instance validate-spec --spec config/rebuild.spec.yaml`
- `femic instance rebuild --spec config/rebuild.spec.yaml --dry-run --run-id mkrf_freshforge_plan`
- `git annex find --not --in arbutus-s3` returned no unpublished annex keys
- `sphinx-build -b html docs docs/_build/html -W`

## Notes
- The workflow uses `config/patchworks.runtime.mkrf_rebuild.windows.yaml` because it is the current canonical MKRF runtime config; `config/patchworks.runtime.windows.yaml` is retained for the PoC benchmark surface.
- This PR depends on the FEMIC P80 provider integration branch/PR being available to provide the `femic` FreshForge provider.

Closes #35