### PR TITLE
Move MKRF FreshForge provider into instance adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,14 @@ canonical rebuild lane:
 - `workflows/freshforge/mkrf_model_build_workflow.yaml`
 
 FreshForge is the declarative workflow and explicit execution surface here. It
-can list the FEMIC providers, validate the MKRF graph, inspect provider
-references, produce a deterministic plan, and run the workflow when requested:
+can list the FEMIC and MKRF providers, validate the MKRF graph, inspect provider
+references, produce a deterministic plan, and run the workflow when requested.
+Install the instance-owned adapter from this repository before using the
+workflow:
+
+```bash
+python -m pip install -e .
+```
 
 ```bash
 freshforge providers
@@ -101,7 +107,9 @@ The first MKRF node validates `config/rebuild.spec.yaml` through
 `femic run`, and BTC/post-TIPSY surfaces still require legacy checkpoint files
 that are not part of the current MKRF accepted source contract. The executable
 MKRF graph therefore starts its regeneration lane at the MKRF-owned
-`femic.mkrf.*` commands after geospatial preflight.
+`mkrf.*` provider nodes after geospatial preflight. Those nodes are owned by
+the adapter package in this instance repository and currently delegate to
+existing `femic instance mkrf-*` compatibility commands.
 
 ## Project Communication Surfaces
 

--- a/docs/rebuild-and-qa.rst
+++ b/docs/rebuild-and-qa.rst
@@ -54,8 +54,8 @@ FreshForge Workflow Boundary
 The FreshForge workflow at
 ``workflows/freshforge/mkrf_model_build_workflow.yaml`` is the declarative
 contract for the MKRF rebuild graph. It records the validate-case through
-matrix-build order, FEMIC provider references, MKRF-owned configuration paths,
-and declared runtime artifacts.
+matrix-build order, reusable FEMIC provider references, MKRF-owned provider
+references, MKRF-owned configuration paths, and declared runtime artifacts.
 
 FreshForge validation, inspection, and planning are non-mutating. FreshForge
 ``run`` explicitly launches provider-owned FEMIC commands in planned order,
@@ -66,6 +66,16 @@ not use the older TSA-style ``femic run`` and BTC/post-TIPSY nodes because those
 still require legacy checkpoint files outside the accepted MKRF source contract.
 ``femic instance rebuild --dry-run`` remains the legacy execution dry-run
 comparison surface for ``config/rebuild.spec.yaml``.
+
+Install this repository's adapter package before running FreshForge commands:
+
+.. code-block:: bash
+
+   python -m pip install -e .
+
+The adapter exposes provider id ``mkrf``. FEMIC core exposes reusable provider
+id ``femic`` and currently retains the ``femic instance mkrf-*`` compatibility
+commands that the MKRF adapter launches.
 
 Benchmark Acceptance Reading
 ----------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,28 @@
+[build-system]
+requires = ["setuptools>=69", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "femic-mkrf-freshforge"
+version = "0.1.0a1"
+description = "MKRF-owned FreshForge provider adapter for FEMIC rebuild workflows"
+readme = "README.md"
+requires-python = ">=3.11"
+license = "MIT"
+authors = [
+    {name = "UBC FRESH Lab"},
+]
+
+[project.entry-points."freshforge.providers"]
+mkrf = "mkrf_freshforge:provider_factory"
+
+[project.optional-dependencies]
+dev = [
+    "pytest",
+]
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/runbooks/REBUILD_RUNBOOK.md
+++ b/runbooks/REBUILD_RUNBOOK.md
@@ -22,15 +22,16 @@ The instance-owned FreshForge graph is:
 
 Use it to validate, inspect, and plan the rebuild graph before execution:
 
-1. `freshforge providers`
-2. `freshforge validate workflows/freshforge/mkrf_model_build_workflow.yaml`
-3. `freshforge inspect workflows/freshforge/mkrf_model_build_workflow.yaml`
-4. `freshforge plan workflows/freshforge/mkrf_model_build_workflow.yaml`
+1. `python -m pip install -e .`
+2. `freshforge providers`
+3. `freshforge validate workflows/freshforge/mkrf_model_build_workflow.yaml`
+4. `freshforge inspect workflows/freshforge/mkrf_model_build_workflow.yaml`
+5. `freshforge plan workflows/freshforge/mkrf_model_build_workflow.yaml`
 
 Run it explicitly only when the local environment is ready for FEMIC, BTC, and
 Patchworks:
 
-5. `freshforge run workflows/freshforge/mkrf_model_build_workflow.yaml --run-id mkrf_freshforge_exec --report runtime/freshforge/runs/mkrf_freshforge_exec.json`
+6. `freshforge run workflows/freshforge/mkrf_model_build_workflow.yaml --run-id mkrf_freshforge_exec --report runtime/freshforge/runs/mkrf_freshforge_exec.json`
 
 FreshForge `validate`, `inspect`, and `plan` are non-mutating. FreshForge `run`
 launches provider-owned FEMIC commands in planned order. The current executable
@@ -40,6 +41,10 @@ require legacy checkpoint files outside the accepted MKRF source contract. It
 still does not materialize DataLad content or inspect declared artifact files in
 this phase. `config/rebuild.spec.yaml` and `femic instance rebuild --dry-run`
 remain the legacy dry-run comparison surface.
+
+The MKRF-specific FreshForge nodes use the `mkrf.*` provider namespace from this
+instance adapter. FEMIC core still supplies reusable `femic.*` nodes and the
+temporary `femic instance mkrf-*` command targets that the adapter launches.
 
 ## Current scope boundary
 

--- a/src/mkrf_freshforge/__init__.py
+++ b/src/mkrf_freshforge/__init__.py
@@ -1,0 +1,515 @@
+"""MKRF-owned FreshForge provider adapter.
+
+The adapter describes MKRF-specific rebuild nodes and executes them by calling
+the installed FEMIC CLI. Scientific logic remains in FEMIC's current
+compatibility commands until a later extraction phase moves that implementation
+behind an instance-owned package boundary.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+PROVIDER_ID = "mkrf"
+PROVIDER_VERSION = "0.1.0a1"
+
+CommandRunner = Callable[[tuple[str, ...]], subprocess.CompletedProcess[str]]
+
+
+@dataclass(frozen=True)
+class _NodeContract:
+    id: str
+    name: str
+    description: str
+    inputs: tuple[str, ...] = ()
+    outputs: tuple[str, ...] = ()
+    parameters: tuple[str, ...] = ()
+    artifacts: tuple[str, ...] = ()
+
+
+_NODE_CONTRACTS: tuple[_NodeContract, ...] = (
+    _NodeContract(
+        id="build_au_inputs",
+        name="Build MKRF AU inputs",
+        description="Build MKRF AU and stand-assignment inputs from Resultant.gdb.",
+        outputs=("au_inputs",),
+        parameters=("instance_root", "resultant_gdb"),
+        artifacts=("au_table", "stand_assignment"),
+    ),
+    _NodeContract(
+        id="select_aus",
+        name="Select MKRF analysis units",
+        description="Publish the canonical MKRF selected AU subset.",
+        inputs=("au_inputs",),
+        outputs=("selected_aus",),
+        parameters=("instance_root",),
+        artifacts=("selected_au_table",),
+    ),
+    _NodeContract(
+        id="build_managed_au_inputs",
+        name="Build MKRF managed AU inputs",
+        description="Build managed AU bootstrap and MSYT input surfaces.",
+        inputs=("selected_aus",),
+        outputs=("managed_au_inputs",),
+        parameters=("instance_root", "resultant_gdb"),
+        artifacts=("stand_origin_assignment", "managed_au_msyt"),
+    ),
+    _NodeContract(
+        id="build_managed_au_curves",
+        name="Build MKRF managed AU curves",
+        description="Run the managed AU BTC curve-building seam.",
+        inputs=("managed_au_inputs",),
+        outputs=("managed_au_curves",),
+        parameters=("instance_root", "run_id"),
+        artifacts=("managed_au_curves", "managed_run_manifest"),
+    ),
+    _NodeContract(
+        id="init_runtime_package",
+        name="Initialize MKRF runtime package",
+        description="Initialize the canonical MKRF Patchworks runtime package.",
+        inputs=("managed_au_curves",),
+        outputs=("patchworks_package",),
+        parameters=("instance_root",),
+        artifacts=("forestmodel_xml", "runtime_manifest"),
+    ),
+)
+
+
+class MkrfFreshForgeProvider:
+    """FreshForge provider for MKRF-specific runtime-package regeneration."""
+
+    def __init__(self, command_runner: CommandRunner | None = None) -> None:
+        self._command_runner = command_runner or _default_command_runner
+
+    def metadata(self) -> Any:
+        """Return FreshForge provider metadata."""
+        return _provider_metadata(
+            provider_id=PROVIDER_ID,
+            name="MKRF model-build provider",
+            description=(
+                "Instance-owned provider for MKRF-specific FEMIC "
+                "runtime-package regeneration validation, planning, and "
+                "explicit execution."
+            ),
+            contracts=_NODE_CONTRACTS,
+        )
+
+    def validate_node(
+        self, node: Any, node_type: Any, *, location: str
+    ) -> tuple[Any, ...]:
+        """Validate broad MKRF node shape without executing FEMIC."""
+        return _validate_contract_node(node, node_type, location=location)
+
+    def execute_node(self, node: Any, node_type: Any, *, context: Any) -> Any:
+        """Execute one MKRF node through the installed FEMIC CLI."""
+        return _execute_with_builder(
+            node=node,
+            node_type=node_type,
+            context=context,
+            builders=_command_builders(),
+            runner=self._command_runner,
+        )
+
+
+def provider_factory() -> MkrfFreshForgeProvider:
+    """Return the MKRF FreshForge provider for entry-point discovery."""
+    return MkrfFreshForgeProvider()
+
+
+def _provider_metadata(
+    *,
+    provider_id: str,
+    name: str,
+    description: str,
+    contracts: Sequence[_NodeContract],
+) -> Any:
+    node_type_metadata, provider_metadata = _freshforge_metadata_types()
+    return provider_metadata(
+        id=provider_id,
+        version=PROVIDER_VERSION,
+        name=name,
+        description=description,
+        node_types=tuple(
+            node_type_metadata(
+                id=contract.id,
+                name=contract.name,
+                description=contract.description,
+                inputs=contract.inputs,
+                outputs=contract.outputs,
+                parameters=contract.parameters,
+                artifacts=contract.artifacts,
+            )
+            for contract in contracts
+        ),
+    )
+
+
+def _validate_contract_node(
+    node: Any,
+    node_type: Any,
+    *,
+    location: str,
+) -> tuple[Any, ...]:
+    diagnostic, severity = _freshforge_diagnostic_types()
+    diagnostics: list[Any] = []
+    diagnostics.extend(
+        _missing_key_diagnostics(
+            diagnostic=diagnostic,
+            severity=severity,
+            required=tuple(node_type.inputs),
+            actual=node.inputs,
+            field_name="inputs",
+            location=location,
+        )
+    )
+    diagnostics.extend(
+        _missing_key_diagnostics(
+            diagnostic=diagnostic,
+            severity=severity,
+            required=tuple(node_type.outputs),
+            actual=node.outputs,
+            field_name="outputs",
+            location=location,
+        )
+    )
+    diagnostics.extend(
+        _missing_key_diagnostics(
+            diagnostic=diagnostic,
+            severity=severity,
+            required=tuple(node_type.parameters),
+            actual=node.parameters,
+            field_name="parameters",
+            location=location,
+        )
+    )
+    artifacts = node.artifacts if isinstance(node.artifacts, dict) else {}
+    diagnostics.extend(
+        _missing_key_diagnostics(
+            diagnostic=diagnostic,
+            severity=severity,
+            required=tuple(node_type.artifacts),
+            actual=artifacts,
+            field_name="artifacts",
+            location=location,
+        )
+    )
+    diagnostics.extend(
+        _empty_parameter_diagnostics(
+            diagnostic=diagnostic,
+            severity=severity,
+            parameters=node.parameters,
+            required=tuple(node_type.parameters),
+            location=location,
+        )
+    )
+    return tuple(diagnostics)
+
+
+def _freshforge_metadata_types() -> tuple[Any, Any]:
+    try:
+        from freshforge.providers import NodeTypeMetadata, ProviderMetadata
+    except ModuleNotFoundError as exc:
+        raise RuntimeError(
+            "The MKRF FreshForge adapter requires FreshForge to be installed."
+        ) from exc
+    return NodeTypeMetadata, ProviderMetadata
+
+
+def _freshforge_diagnostic_types() -> tuple[Any, Any]:
+    try:
+        from freshforge.records import Diagnostic, DiagnosticSeverity
+    except ModuleNotFoundError as exc:
+        raise RuntimeError(
+            "The MKRF FreshForge adapter requires FreshForge to be installed."
+        ) from exc
+    return Diagnostic, DiagnosticSeverity
+
+
+def _freshforge_execution_result_type() -> Any:
+    try:
+        from freshforge.records import ProviderExecutionResult
+    except ModuleNotFoundError as exc:
+        raise RuntimeError(
+            "The MKRF FreshForge adapter requires FreshForge to be installed."
+        ) from exc
+    return ProviderExecutionResult
+
+
+def _execute_with_builder(
+    *,
+    node: Any,
+    node_type: Any,
+    context: Any,
+    builders: dict[str, Callable[[Any, Any], tuple[str, ...]]],
+    runner: CommandRunner,
+) -> Any:
+    _ = context
+    result_type = _freshforge_execution_result_type()
+    diagnostic, severity = _freshforge_diagnostic_types()
+    builder = builders.get(str(node_type.id))
+    if builder is None:
+        return result_type(
+            diagnostics=(
+                diagnostic(
+                    severity=severity.ERROR,
+                    code="mkrf.execution.unsupported",
+                    message=(
+                        f"MKRF provider has no execution hook for node type "
+                        f"'{node_type.id}'."
+                    ),
+                    location=f"nodes.{node.id}",
+                ),
+            )
+        )
+    try:
+        command = builder(node, context)
+    except ValueError as exc:
+        return result_type(
+            diagnostics=(
+                diagnostic(
+                    severity=severity.ERROR,
+                    code="mkrf.execution.parameters.invalid",
+                    message=str(exc),
+                    location=f"nodes.{node.id}.parameters",
+                ),
+            )
+        )
+    completed = runner(command)
+    metadata: dict[str, Any] = {"returncode": completed.returncode}
+    if completed.stdout:
+        metadata["stdout"] = completed.stdout
+    if completed.stderr:
+        metadata["stderr"] = completed.stderr
+    diagnostics: tuple[Any, ...] = ()
+    if completed.returncode != 0:
+        diagnostics = (
+            diagnostic(
+                severity=severity.ERROR,
+                code="mkrf.execution.command.failed",
+                message=(
+                    f"MKRF command for node '{node.id}' exited with "
+                    f"return code {completed.returncode}."
+                ),
+                location=f"nodes.{node.id}",
+            ),
+        )
+    artifacts = node.artifacts if isinstance(node.artifacts, dict) else {}
+    return result_type(
+        metadata=metadata,
+        command=command,
+        diagnostics=diagnostics,
+        artifacts=artifacts,
+    )
+
+
+def _default_command_runner(
+    command: tuple[str, ...],
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        list(command),
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _python_m_femic(*args: str) -> tuple[str, ...]:
+    return (sys.executable, "-m", "femic", *args)
+
+
+def _parameter(node: Any, key: str) -> str:
+    value = node.parameters.get(key)
+    if value is None:
+        raise ValueError(f"MKRF node '{node.id}' requires parameter '{key}'.")
+    if isinstance(value, str):
+        if not value.strip():
+            raise ValueError(f"MKRF node '{node.id}' parameter '{key}' is empty.")
+        return value
+    return str(value)
+
+
+def _optional_parameter(node: Any, key: str) -> str | None:
+    value = node.parameters.get(key)
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value if value.strip() else None
+    return str(value)
+
+
+def _append_option(command: list[str], node: Any, key: str, option: str) -> None:
+    value = _optional_parameter(node, key)
+    if value is not None:
+        command.extend([option, value])
+
+
+def _command_builders() -> dict[str, Callable[[Any, Any], tuple[str, ...]]]:
+    return {
+        "build_au_inputs": _build_au_inputs_command,
+        "select_aus": _build_select_aus_command,
+        "build_managed_au_inputs": _build_managed_au_inputs_command,
+        "build_managed_au_curves": _build_managed_au_curves_command,
+        "init_runtime_package": _build_init_runtime_package_command,
+    }
+
+
+def _build_au_inputs_command(node: Any, _context: Any) -> tuple[str, ...]:
+    command = list(
+        _python_m_femic(
+            "instance",
+            "mkrf-build-au-inputs",
+            "--instance-root",
+            _parameter(node, "instance_root"),
+            "--resultant-gdb",
+            _parameter(node, "resultant_gdb"),
+        )
+    )
+    _append_option(command, node, "output_dir", "--output-dir")
+    return tuple(command)
+
+
+def _build_select_aus_command(node: Any, _context: Any) -> tuple[str, ...]:
+    command = list(
+        _python_m_femic(
+            "instance",
+            "mkrf-select-aus",
+            "--instance-root",
+            _parameter(node, "instance_root"),
+        )
+    )
+    _append_option(command, node, "au_table_csv", "--au-table-csv")
+    _append_option(command, node, "assignment_csv", "--assignment-csv")
+    _append_option(command, node, "output_csv", "--output-csv")
+    _append_option(command, node, "target_coverage", "--target-coverage")
+    return tuple(command)
+
+
+def _build_managed_au_inputs_command(node: Any, _context: Any) -> tuple[str, ...]:
+    command = list(
+        _python_m_femic(
+            "instance",
+            "mkrf-build-managed-au-inputs",
+            "--instance-root",
+            _parameter(node, "instance_root"),
+            "--resultant-gdb",
+            _parameter(node, "resultant_gdb"),
+        )
+    )
+    _append_option(command, node, "tipsy_rules_yaml", "--tipsy-rules-yaml")
+    _append_option(command, node, "selected_au_csv", "--selected-au-csv")
+    _append_option(command, node, "assignment_csv", "--assignment-csv")
+    _append_option(command, node, "output_dir", "--output-dir")
+    return tuple(command)
+
+
+def _build_managed_au_curves_command(node: Any, _context: Any) -> tuple[str, ...]:
+    command = list(
+        _python_m_femic(
+            "instance",
+            "mkrf-build-managed-au-curves",
+            "--instance-root",
+            _parameter(node, "instance_root"),
+            "--run-id",
+            _parameter(node, "run_id"),
+        )
+    )
+    _append_option(command, node, "bootstrap_csv", "--bootstrap-csv")
+    _append_option(command, node, "msyt_csv", "--msyt-csv")
+    _append_option(command, node, "output_dir", "--output-dir")
+    _append_option(command, node, "log_dir", "--log-dir")
+    _append_option(command, node, "btc_executable", "--btc-executable")
+    return tuple(command)
+
+
+def _build_init_runtime_package_command(node: Any, _context: Any) -> tuple[str, ...]:
+    command = list(
+        _python_m_femic(
+            "instance",
+            "mkrf-init-runtime-package",
+            "--instance-root",
+            _parameter(node, "instance_root"),
+        )
+    )
+    _append_option(command, node, "package_root", "--package-root")
+    _append_option(command, node, "selected_au_csv", "--selected-au-csv")
+    _append_option(
+        command,
+        node,
+        "stand_origin_assignment_csv",
+        "--stand-origin-assignment-csv",
+    )
+    _append_option(
+        command, node, "stand_au_assignment_csv", "--stand-au-assignment-csv"
+    )
+    _append_option(command, node, "managed_bootstrap_csv", "--managed-bootstrap-csv")
+    _append_option(
+        command, node, "first_growth_curves_csv", "--first-growth-curves-csv"
+    )
+    _append_option(
+        command,
+        node,
+        "first_growth_diagnostics_csv",
+        "--first-growth-diagnostics-csv",
+    )
+    _append_option(command, node, "managed_curves_csv", "--managed-curves-csv")
+    _append_option(
+        command, node, "managed_run_manifest_json", "--managed-run-manifest-json"
+    )
+    _append_option(
+        command,
+        node,
+        "bad_curve_audit_summary_csv",
+        "--bad-curve-audit-summary-csv",
+    )
+    return tuple(command)
+
+
+def _missing_key_diagnostics(
+    *,
+    diagnostic: Any,
+    severity: Any,
+    required: tuple[str, ...],
+    actual: dict[str, Any],
+    field_name: str,
+    location: str,
+) -> tuple[Any, ...]:
+    return tuple(
+        diagnostic(
+            severity=severity.ERROR,
+            code=f"mkrf.{field_name}.missing",
+            message=(
+                f"MKRF node requires {field_name} key '{key}' for "
+                "FreshForge validation, planning, and execution."
+            ),
+            location=f"{location}.{field_name}.{key}",
+        )
+        for key in required
+        if key not in actual
+    )
+
+
+def _empty_parameter_diagnostics(
+    *,
+    diagnostic: Any,
+    severity: Any,
+    parameters: dict[str, Any],
+    required: tuple[str, ...],
+    location: str,
+) -> tuple[Any, ...]:
+    diagnostics: list[Any] = []
+    for key in required:
+        value = parameters.get(key)
+        if isinstance(value, str) and not value.strip():
+            diagnostics.append(
+                diagnostic(
+                    severity=severity.ERROR,
+                    code="mkrf.parameters.empty",
+                    message=f"MKRF node parameter '{key}' must be nonempty.",
+                    location=f"{location}.parameters.{key}",
+                )
+            )
+    return tuple(diagnostics)

--- a/tests/test_mkrf_freshforge.py
+++ b/tests/test_mkrf_freshforge.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+import pytest
+
+from mkrf_freshforge import MkrfFreshForgeProvider, provider_factory
+
+freshforge = pytest.importorskip("freshforge")
+
+WORKFLOW_PATH = Path("workflows/freshforge/mkrf_model_build_workflow.yaml")
+EXPECTED_MODEL_BUILD_ORDER = [
+    "validate_case",
+    "geospatial_preflight",
+    "build_au_inputs",
+    "select_aus",
+    "build_managed_au_inputs",
+    "build_managed_au_curves",
+    "init_runtime_package",
+    "patchworks_preflight",
+    "matrix_build",
+]
+
+
+def _successful_runner(commands: list[tuple[str, ...]]):
+    def _run(command: tuple[str, ...]) -> subprocess.CompletedProcess[str]:
+        commands.append(command)
+        return subprocess.CompletedProcess(
+            args=list(command),
+            returncode=0,
+            stdout="ok",
+            stderr="",
+        )
+
+    return _run
+
+
+def _registry_with_femic_and_mkrf():
+    from femic.freshforge import provider_factory as femic_provider_factory
+    from freshforge.providers import ProviderRegistry
+
+    registry = ProviderRegistry()
+    registry.register(femic_provider_factory())
+    registry.register(provider_factory())
+    return registry
+
+
+def test_provider_metadata_serializes_deterministically() -> None:
+    metadata = provider_factory().metadata()
+
+    assert metadata.id == "mkrf"
+    assert [node_type.id for node_type in metadata.node_types] == [
+        "build_au_inputs",
+        "select_aus",
+        "build_managed_au_inputs",
+        "build_managed_au_curves",
+        "init_runtime_package",
+    ]
+    assert metadata.to_dict()["node_types"][0]["parameters"] == [
+        "instance_root",
+        "resultant_gdb",
+    ]
+
+
+def test_pyproject_declares_mkrf_freshforge_entry_point() -> None:
+    pyproject = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+
+    entry_points = pyproject["project"]["entry-points"]["freshforge.providers"]
+    assert entry_points["mkrf"] == "mkrf_freshforge:provider_factory"
+
+
+def test_provider_execution_constructs_femic_command() -> None:
+    from freshforge.records import ExecutionContext, WorkflowNode
+
+    commands: list[tuple[str, ...]] = []
+    provider = MkrfFreshForgeProvider(command_runner=_successful_runner(commands))
+    node_type = next(
+        item for item in provider.metadata().node_types if item.id == "build_au_inputs"
+    )
+    node = WorkflowNode(
+        id="build_au_inputs",
+        provider="mkrf.build_au_inputs",
+        parameters={
+            "instance_root": ".",
+            "resultant_gdb": "data/source/03_MappingAnalysisData/Resultant.gdb",
+        },
+    )
+
+    result = provider.execute_node(
+        node,
+        node_type,
+        context=ExecutionContext(workflow_id="wf", run_id="run"),
+    )
+
+    assert result.diagnostics == ()
+    assert commands == [
+        (
+            sys.executable,
+            "-m",
+            "femic",
+            "instance",
+            "mkrf-build-au-inputs",
+            "--instance-root",
+            ".",
+            "--resultant-gdb",
+            "data/source/03_MappingAnalysisData/Resultant.gdb",
+        )
+    ]
+
+
+def test_workflow_validates_and_plans_with_mkrf_provider() -> None:
+    from freshforge.loading import load_workflow
+    from freshforge.planning import create_run_plan
+    from freshforge.validation import validate_workflow_with_providers
+
+    spec, load_diagnostics = load_workflow(WORKFLOW_PATH)
+    assert spec is not None
+    assert load_diagnostics == []
+
+    registry = _registry_with_femic_and_mkrf()
+    diagnostics = validate_workflow_with_providers(
+        spec,
+        registry=registry,
+        structural_diagnostics=load_diagnostics,
+    )
+    assert diagnostics == []
+
+    plan = create_run_plan(spec, diagnostics=diagnostics, registry=registry)
+    assert not plan.has_errors
+    assert [node.id for node in plan.nodes] == EXPECTED_MODEL_BUILD_ORDER
+    assert {node.provider_id for node in plan.nodes} == {"femic", "mkrf"}
+
+
+def test_workflow_dry_run_uses_mkrf_provider() -> None:
+    from freshforge.execution import execute_workflow
+    from freshforge.loading import load_workflow
+
+    spec, load_diagnostics = load_workflow(WORKFLOW_PATH)
+    assert spec is not None
+
+    report = execute_workflow(
+        spec,
+        run_id="mkrf_freshforge_exec",
+        diagnostics=load_diagnostics,
+        registry=_registry_with_femic_and_mkrf(),
+        dry_run=True,
+    )
+
+    assert not report.failed
+    assert report.dry_run
+    assert report.planned_order == tuple(EXPECTED_MODEL_BUILD_ORDER)

--- a/workflows/freshforge/mkrf_model_build_workflow.yaml
+++ b/workflows/freshforge/mkrf_model_build_workflow.yaml
@@ -23,7 +23,7 @@ nodes:
     parameters:
       instance_root: .
   - id: build_au_inputs
-    provider: femic.mkrf.build_au_inputs
+    provider: mkrf.build_au_inputs
     needs:
       - geospatial_preflight
     inputs:
@@ -38,7 +38,7 @@ nodes:
       au_table: data/model_input_bundle/au_table.csv
       stand_assignment: data/model_input_bundle/stand_au_assignment.csv
   - id: select_aus
-    provider: femic.mkrf.select_aus
+    provider: mkrf.select_aus
     needs:
       - build_au_inputs
     inputs:
@@ -54,7 +54,7 @@ nodes:
     artifacts:
       selected_au_table: data/model_input_bundle/selected_au_table.csv
   - id: build_managed_au_inputs
-    provider: femic.mkrf.build_managed_au_inputs
+    provider: mkrf.build_managed_au_inputs
     needs:
       - select_aus
     inputs:
@@ -72,7 +72,7 @@ nodes:
       stand_origin_assignment: data/model_input_bundle/stand_origin_assignment.csv
       managed_au_msyt: data/model_input_bundle/managed_au_msyt.csv
   - id: build_managed_au_curves
-    provider: femic.mkrf.build_managed_au_curves
+    provider: mkrf.build_managed_au_curves
     needs:
       - build_managed_au_inputs
     inputs:
@@ -90,7 +90,7 @@ nodes:
       managed_au_curves: data/model_input_bundle/managed_au_curves.csv
       managed_run_manifest: data/model_input_bundle/managed_au_run_manifest.json
   - id: init_runtime_package
-    provider: femic.mkrf.init_runtime_package
+    provider: mkrf.init_runtime_package
     needs:
       - build_managed_au_curves
     inputs:


### PR DESCRIPTION
﻿## Summary
- adds an instance-owned `mkrf_freshforge` adapter package with provider id `mkrf`
- rewrites the MKRF workflow from `femic.mkrf.*` to `mkrf.*`
- updates README/docs/runbook installation and ownership language

## Verification
- `..\..\.venv\Scripts\python.exe -m pip install -e .`
- `..\..\.venv\Scripts\python.exe -m ruff check src tests`
- `..\..\.venv\Scripts\python.exe -m pytest tests/test_mkrf_freshforge.py`
- `..\..\.venv\Scripts\freshforge.exe validate workflows\freshforge\mkrf_model_build_workflow.yaml --json`
- `..\..\.venv\Scripts\freshforge.exe inspect workflows\freshforge\mkrf_model_build_workflow.yaml --json`
- `..\..\.venv\Scripts\freshforge.exe plan workflows\freshforge\mkrf_model_build_workflow.yaml --json`
- `..\..\.venv\Scripts\freshforge.exe run workflows\freshforge\mkrf_model_build_workflow.yaml --run-id mkrf_freshforge_exec --dry-run --json`
- `..\..\.venv\Scripts\sphinx-build.exe -b html docs docs\_build\html -W`
- `..\..\.venv\Scripts\python.exe -m build`
- `..\..\.venv\Scripts\python.exe -m twine check dist\*`

Closes #39.
