### PR TITLE
P86: move MKRF workflow implementation into instance package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# femic-mkrf-instance
+﻿# femic-mkrf-instance
 
 Private standalone **MKRF FEMIC instance** for the canonical from-scratch
 rebuild lane, with retained PoC and legacy evidence surfaces kept alongside it
@@ -109,7 +109,7 @@ that are not part of the current MKRF accepted source contract. The executable
 MKRF graph therefore starts its regeneration lane at the MKRF-owned
 `mkrf.*` provider nodes after geospatial preflight. Those nodes are owned by
 the adapter package in this instance repository and currently delegate to
-existing `femic instance mkrf-*` compatibility commands.
+the instance-owned `python -m mkrf_femic ...` commands.
 
 ## Project Communication Surfaces
 
@@ -361,4 +361,5 @@ Policy:
    only after the real MKRF boundary and checkpoint inputs are published.
 
 See `runbooks/REBUILD_RUNBOOK.md` for the current thin-baseline boundary.
+
 

--- a/docs/operator-runbook.rst
+++ b/docs/operator-runbook.rst
@@ -1,4 +1,4 @@
-Operator Runbook
+﻿Operator Runbook
 ================
 
 Minimal Operator Path
@@ -60,7 +60,7 @@ Minimal Operator Path
 
 7. After a canonical smoke run, audit the saved stage directly:
 
-   - ``femic instance mkrf-audit-runtime-sanity --instance-root . --stage-dir runtime/logs/headless_stage/<run-id>``
+   - ``mkrf-femic mkrf-audit-runtime-sanity --instance-root . --stage-dir runtime/logs/headless_stage/<run-id>``
 
 8. Use the retained PoC package only for benchmark/reference comparison:
 
@@ -183,3 +183,4 @@ Key Reads
 - ``runbooks/REBUILD_RUNBOOK.md``
 - ``runbooks/LEGACY_REBUILD_READINESS_CRITERIA.md``
 - ``runbooks/LEGACY_SOURCE_REPRODUCIBILITY_BOUNDARY.md``
+

--- a/docs/rebuild-and-qa.rst
+++ b/docs/rebuild-and-qa.rst
@@ -1,4 +1,4 @@
-Rebuild and QA
+﻿Rebuild and QA
 ==============
 
 Current Rebuild Meaning
@@ -74,8 +74,7 @@ Install this repository's adapter package before running FreshForge commands:
    python -m pip install -e .
 
 The adapter exposes provider id ``mkrf``. FEMIC core exposes reusable provider
-id ``femic`` and currently retains the ``femic instance mkrf-*`` compatibility
-commands that the MKRF adapter launches.
+id ``femic`` and no longer owns MKRF-specific ``mkrf-*`` commands. The MKRF instance package owns those commands through ``mkrf-femic`` and ``python -m mkrf_femic``.
 
 Benchmark Acceptance Reading
 ----------------------------
@@ -140,7 +139,7 @@ The current accepted operator-grade smoke for the canonical lane is:
    and
 4. audit the saved stage with:
 
-   - ``femic instance mkrf-audit-runtime-sanity --instance-root . --stage-dir <saved-stage>``
+   - ``mkrf-femic mkrf-audit-runtime-sanity --instance-root . --stage-dir <saved-stage>``
 
 The saved-stage sanity audit is intended to catch cases where a species family
 is emitted structurally but carries zero or contradictory signal relative to
@@ -150,19 +149,18 @@ Cedar-pole CT validation lane
 -----------------------------
 
 After changing the canonical cedar-pole ``CT`` implementation, regenerate the
-managed inputs, managed curves, and runtime package from the parent FEMIC
-checkout using the project virtual environment:
+managed inputs, managed curves, and runtime package from this MKRF instance checkout after installing the instance package:
 
-- ``femic instance mkrf-build-managed-au-inputs --instance-root external\femic-mkrf-instance --resultant-gdb external\femic-mkrf-instance\data\source\03_MappingAnalysisData\Resultant.gdb``
-- ``femic instance mkrf-build-managed-au-curves --instance-root external\femic-mkrf-instance``
-- ``femic instance mkrf-init-runtime-package --instance-root external\femic-mkrf-instance``
+- ``mkrf-femic mkrf-build-managed-au-inputs --instance-root external\femic-mkrf-instance --resultant-gdb external\femic-mkrf-instance\data\source\03_MappingAnalysisData\Resultant.gdb``
+- ``mkrf-femic mkrf-build-managed-au-curves --instance-root external\femic-mkrf-instance``
+- ``mkrf-femic mkrf-init-runtime-package --instance-root external\femic-mkrf-instance``
 
 Then validate the CT-specific runtime surface:
 
 - ``femic patchworks preflight --instance-root external\femic-mkrf-instance --config config\patchworks.runtime.mkrf_rebuild.windows.yaml``
 - ``femic patchworks matrix-build --instance-root external\femic-mkrf-instance --config config\patchworks.runtime.mkrf_rebuild.windows.yaml --run-id <ct-run-id>``
 - ``femic patchworks run-default-scenario mkrf.base --run-id <ct-smoke-run-id>``
-- ``femic instance mkrf-audit-runtime-sanity --instance-root external\femic-mkrf-instance --stage-dir <saved-stage>``
+- ``mkrf-femic mkrf-audit-runtime-sanity --instance-root external\femic-mkrf-instance --stage-dir <saved-stage>``
 - ``pytest tests/test_mkrf_managed.py tests/test_mkrf_runtime_package.py tests/test_tipsy_config.py``
 - confirm ``models/mkrf_patchworks_model/xml/forestmodel.xml`` contains
   ``CT35``, ``CT40``, and ``CT45`` only for CT bucket treatments;
@@ -179,18 +177,18 @@ After changing MKRF AU stratification, aggregation, or selected-AU publication
 logic, regenerate the AU and runtime surfaces from the parent FEMIC checkout
 using the project virtual environment:
 
-- ``femic instance mkrf-build-au-inputs --instance-root external\femic-mkrf-instance --resultant-gdb external\femic-mkrf-instance\data\source\03_MappingAnalysisData\Resultant.gdb``
-- ``femic instance mkrf-select-aus --instance-root external\femic-mkrf-instance``
-- ``femic instance mkrf-build-managed-au-inputs --instance-root external\femic-mkrf-instance --resultant-gdb external\femic-mkrf-instance\data\source\03_MappingAnalysisData\Resultant.gdb``
-- ``femic instance mkrf-build-managed-au-curves --instance-root external\femic-mkrf-instance --run-id <run-id>``
-- ``femic instance mkrf-init-runtime-package --instance-root external\femic-mkrf-instance``
+- ``mkrf-femic mkrf-build-au-inputs --instance-root external\femic-mkrf-instance --resultant-gdb external\femic-mkrf-instance\data\source\03_MappingAnalysisData\Resultant.gdb``
+- ``mkrf-femic mkrf-select-aus --instance-root external\femic-mkrf-instance``
+- ``mkrf-femic mkrf-build-managed-au-inputs --instance-root external\femic-mkrf-instance --resultant-gdb external\femic-mkrf-instance\data\source\03_MappingAnalysisData\Resultant.gdb``
+- ``mkrf-femic mkrf-build-managed-au-curves --instance-root external\femic-mkrf-instance --run-id <run-id>``
+- ``mkrf-femic mkrf-init-runtime-package --instance-root external\femic-mkrf-instance``
 
 Then validate the regenerated runtime:
 
 - ``femic patchworks preflight --instance-root external\femic-mkrf-instance --config config\patchworks.runtime.mkrf_rebuild.windows.yaml``
 - ``femic patchworks matrix-build --instance-root external\femic-mkrf-instance --config config\patchworks.runtime.mkrf_rebuild.windows.yaml --run-id <matrix-run-id>``
 - ``femic patchworks run-default-scenario mkrf.base --run-id <smoke-run-id>``
-- ``femic instance mkrf-audit-runtime-sanity --instance-root external\femic-mkrf-instance --stage-dir <saved-stage>``
+- ``mkrf-femic mkrf-audit-runtime-sanity --instance-root external\femic-mkrf-instance --stage-dir <saved-stage>``
 - ``pytest tests/test_mkrf_au.py tests/test_mkrf_managed.py tests/test_mkrf_runtime_package.py``
 - inspect ``data/model_input_bundle/au_aggregation_audit.csv`` and
   ``data/model_input_bundle/selected_au_table.csv`` directly;
@@ -231,3 +229,4 @@ The canonical closeout phase should decide:
   necessity requires it; and
 - what legacy seams to leave behind because they are not part of the desired
   FEMIC-native structure.
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,13 +5,20 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "femic-mkrf-freshforge"
 version = "0.1.0a1"
-description = "MKRF-owned FreshForge provider adapter for FEMIC rebuild workflows"
+description = "MKRF-owned FEMIC workflow implementation and FreshForge provider adapter"
 readme = "README.md"
 requires-python = ">=3.11"
 license = "MIT"
 authors = [
     {name = "UBC FRESH Lab"},
 ]
+dependencies = [
+    "rich",
+    "typer",
+]
+
+[project.scripts]
+mkrf-femic = "mkrf_femic.cli:app"
 
 [project.entry-points."freshforge.providers"]
 mkrf = "mkrf_freshforge:provider_factory"

--- a/src/mkrf_femic/__init__.py
+++ b/src/mkrf_femic/__init__.py
@@ -1,0 +1,1 @@
+"""MKRF-owned FEMIC workflow implementation package."""

--- a/src/mkrf_femic/__main__.py
+++ b/src/mkrf_femic/__main__.py
@@ -1,0 +1,8 @@
+"""Run the MKRF FEMIC CLI with ``python -m mkrf_femic``."""
+
+from __future__ import annotations
+
+from mkrf_femic.cli import app
+
+
+app()

--- a/src/mkrf_femic/cli.py
+++ b/src/mkrf_femic/cli.py
@@ -1,0 +1,618 @@
+"""Command line interface for MKRF-owned FEMIC workflow implementation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+from rich.console import Console
+
+from mkrf_femic.workflows.mkrf import (
+    audit_mkrf_runtime_sanity,
+    build_mkrf_bad_curve_audit,
+    build_mkrf_all_plots,
+    build_mkrf_au_distribution_plot,
+    build_mkrf_au_input_bundle,
+    build_mkrf_first_growth_input_bundle,
+    build_mkrf_managed_au_curves,
+    build_mkrf_managed_au_input_bundle,
+    build_mkrf_selected_au_input_bundle,
+    initialize_mkrf_runtime_package,
+    publish_mkrf_runtime_spatial_handoff,
+)
+
+console = Console()
+app = typer.Typer(
+    add_completion=False,
+    no_args_is_help=True,
+    help="MKRF-owned FEMIC workflow commands.",
+)
+INSTANCE_ROOT_OPTION = typer.Option(
+    None,
+    "--instance-root",
+    help="Path to the MKRF instance root. Defaults to the current directory.",
+)
+
+
+class _InstanceContext:
+    def __init__(self, instance_root: Path) -> None:
+        self.instance_root = instance_root.resolve()
+
+    def resolve_path(self, path: Path) -> Path:
+        if path.is_absolute():
+            return path
+        return self.instance_root / path
+
+
+def _resolve_cli_instance_context(*, instance_root: Path | None) -> _InstanceContext:
+    return _InstanceContext(instance_root or Path("."))
+
+
+@app.command("mkrf-build-au-inputs")
+def instance_mkrf_build_au_inputs(
+    resultant_gdb: Path = typer.Option(
+        ...,
+        "--resultant-gdb",
+        exists=True,
+        file_okay=False,
+        dir_okay=True,
+        resolve_path=True,
+        help="Path to the upstream MKRF Resultant.gdb directory.",
+    ),
+    output_dir: Path = typer.Option(
+        Path("data/model_input_bundle"),
+        "--output-dir",
+        help="Instance-relative output directory for AU input bundle CSVs.",
+    ),
+    instance_root: Path | None = INSTANCE_ROOT_OPTION,
+) -> None:
+    """Build MKRF AU and stand-assignment inputs from Resultant.gdb."""
+    context = _resolve_cli_instance_context(instance_root=instance_root)
+    result = build_mkrf_au_input_bundle(
+        resultant_gdb=resultant_gdb,
+        output_dir=context.resolve_path(output_dir),
+    )
+    console.print(
+        "[green]mkrf au inputs built[/green] "
+        f"source_rows={result.source_row_count} aus={result.au_count}"
+    )
+    console.print(f"au_table: {result.au_table_path}")
+    console.print(f"stand_assignment: {result.stand_assignment_path}")
+
+
+@app.command("mkrf-build-first-growth-curves")
+def instance_mkrf_build_first_growth_curves(
+    vdyp_yields_csv: Path = typer.Option(
+        ...,
+        "--vdyp-yields-csv",
+        exists=True,
+        dir_okay=False,
+        file_okay=True,
+        resolve_path=True,
+        help="Path to the upstream MKRF VDYP_Yields.csv file.",
+    ),
+    assignment_csv: Path = typer.Option(
+        Path("data/model_input_bundle/stand_au_assignment.csv"),
+        "--assignment-csv",
+        help="Instance-relative stand-to-AU assignment CSV.",
+    ),
+    resultant_gdb: Path = typer.Option(
+        ...,
+        "--resultant-gdb",
+        exists=True,
+        dir_okay=True,
+        file_okay=True,
+        resolve_path=True,
+        help="Path to the upstream MKRF Resultant.gdb used for lexmatch fallback.",
+    ),
+    output_dir: Path = typer.Option(
+        Path("data/model_input_bundle"),
+        "--output-dir",
+        help="Instance-relative output directory for AU-wise first-growth CSVs.",
+    ),
+    instance_root: Path | None = INSTANCE_ROOT_OPTION,
+) -> None:
+    """Build MKRF AU-wise first-growth curves from VDYP stand evidence."""
+    context = _resolve_cli_instance_context(instance_root=instance_root)
+    result = build_mkrf_first_growth_input_bundle(
+        vdyp_yields_csv=vdyp_yields_csv,
+        assignment_csv=context.resolve_path(assignment_csv),
+        resultant_gdb=resultant_gdb,
+        output_dir=context.resolve_path(output_dir),
+    )
+    console.print(
+        "[green]mkrf first-growth curves built[/green] "
+        f"aus={result.au_count} assigned_stands={result.assigned_stand_count} "
+        f"raw_unmatched_source_stands={result.raw_unmatched_source_stand_count} "
+        f"residual_unmatched_source_stands={result.residual_unmatched_source_stand_count} "
+        f"lexmatch_assigned_stands={result.lexmatch_assigned_stand_count}"
+    )
+    console.print(f"curves: {result.curves_path}")
+    console.print(f"diagnostics: {result.diagnostics_path}")
+
+
+@app.command("mkrf-plot-au-distribution")
+def instance_mkrf_plot_au_distribution(
+    resultant_gdb: Path = typer.Option(
+        ...,
+        "--resultant-gdb",
+        exists=True,
+        dir_okay=True,
+        file_okay=True,
+        resolve_path=True,
+        help="Path to the upstream MKRF Resultant.gdb source surface.",
+    ),
+    assignment_csv: Path = typer.Option(
+        Path("data/model_input_bundle/stand_au_assignment.csv"),
+        "--assignment-csv",
+        help="Instance-relative stand-to-AU assignment CSV.",
+    ),
+    selected_au_csv: Path = typer.Option(
+        Path("data/model_input_bundle/selected_au_table.csv"),
+        "--selected-au-csv",
+        help="Instance-relative selected-AU table CSV used to filter the plotted subset.",
+    ),
+    output_dir: Path = typer.Option(
+        Path("plots"),
+        "--output-dir",
+        help="Instance-relative output directory for AU distribution plots.",
+    ),
+    instance_root: Path | None = INSTANCE_ROOT_OPTION,
+) -> None:
+    """Build the MKRF AU abundance/site-index distribution plot."""
+    context = _resolve_cli_instance_context(instance_root=instance_root)
+    result = build_mkrf_au_distribution_plot(
+        resultant_gdb=resultant_gdb,
+        assignment_csv=context.resolve_path(assignment_csv),
+        selected_au_csv=context.resolve_path(selected_au_csv),
+        output_dir=context.resolve_path(output_dir),
+    )
+    console.print(
+        "[green]mkrf au distribution plot built[/green] "
+        f"aus={result.au_count} site_index_points={result.point_count}"
+    )
+    console.print(f"png: {result.png_path}")
+    console.print(f"pdf: {result.pdf_path}")
+
+
+@app.command("mkrf-select-aus")
+def instance_mkrf_select_aus(
+    au_table_csv: Path = typer.Option(
+        Path("data/model_input_bundle/au_table.csv"),
+        "--au-table-csv",
+        help="Instance-relative canonical AU table CSV.",
+    ),
+    assignment_csv: Path = typer.Option(
+        Path("data/model_input_bundle/stand_au_assignment.csv"),
+        "--assignment-csv",
+        help="Instance-relative stand-to-AU assignment CSV.",
+    ),
+    output_csv: Path = typer.Option(
+        Path("data/model_input_bundle/selected_au_table.csv"),
+        "--output-csv",
+        help="Instance-relative output CSV for the selected top-N AU subset.",
+    ),
+    target_coverage: float = typer.Option(
+        0.95,
+        "--target-coverage",
+        min=0.0,
+        max=1.0,
+        help="Cumulative covered-area share cutoff for the selected AU subset.",
+    ),
+    instance_root: Path | None = INSTANCE_ROOT_OPTION,
+) -> None:
+    """Publish the canonical top-N AU subset by cumulative covered-area share."""
+    context = _resolve_cli_instance_context(instance_root=instance_root)
+    result = build_mkrf_selected_au_input_bundle(
+        au_table_csv=context.resolve_path(au_table_csv),
+        assignment_csv=context.resolve_path(assignment_csv),
+        output_path=context.resolve_path(output_csv),
+        target_coverage=target_coverage,
+    )
+    console.print(
+        "[green]mkrf selected au table built[/green] "
+        f"selected_aus={result.selected_au_count} total_aus={result.total_au_count} "
+        f"target_coverage={result.target_coverage:.3f} "
+        f"realized_coverage={result.realized_coverage:.6f}"
+    )
+    console.print(f"selected_au_table: {result.output_path}")
+
+
+@app.command("mkrf-recompile-plots")
+def instance_mkrf_recompile_plots(
+    resultant_gdb: Path = typer.Option(
+        ...,
+        "--resultant-gdb",
+        exists=True,
+        dir_okay=True,
+        file_okay=True,
+        resolve_path=True,
+        help="Path to the upstream MKRF Resultant.gdb source surface.",
+    ),
+    vdyp_yields_csv: Path = typer.Option(
+        ...,
+        "--vdyp-yields-csv",
+        exists=True,
+        dir_okay=False,
+        file_okay=True,
+        resolve_path=True,
+        help="Path to the upstream MKRF VDYP_Yields.csv file.",
+    ),
+    assignment_csv: Path = typer.Option(
+        Path("data/model_input_bundle/stand_au_assignment.csv"),
+        "--assignment-csv",
+        help="Instance-relative stand-to-AU assignment CSV.",
+    ),
+    selected_au_csv: Path = typer.Option(
+        Path("data/model_input_bundle/selected_au_table.csv"),
+        "--selected-au-csv",
+        help="Instance-relative selected-AU table CSV.",
+    ),
+    first_growth_curves_csv: Path = typer.Option(
+        Path("data/model_input_bundle/first_growth_au_curves.csv"),
+        "--first-growth-curves-csv",
+        help="Instance-relative AU-wise first-growth curves CSV.",
+    ),
+    managed_curves_csv: Path = typer.Option(
+        Path("data/model_input_bundle/managed_au_curves.csv"),
+        "--managed-curves-csv",
+        help="Instance-relative AU-wise managed curves CSV.",
+    ),
+    output_dir: Path = typer.Option(
+        Path("plots"),
+        "--output-dir",
+        help="Instance-relative output directory for regenerated plots.",
+    ),
+    instance_root: Path | None = INSTANCE_ROOT_OPTION,
+) -> None:
+    """Rebuild the MKRF AU strata, VDYP diagnostics, and TIPSY comparison plots."""
+    context = _resolve_cli_instance_context(instance_root=instance_root)
+    result = build_mkrf_all_plots(
+        resultant_gdb=resultant_gdb,
+        assignment_csv=context.resolve_path(assignment_csv),
+        selected_au_csv=context.resolve_path(selected_au_csv),
+        first_growth_curves_csv=context.resolve_path(first_growth_curves_csv),
+        managed_curves_csv=context.resolve_path(managed_curves_csv),
+        vdyp_yields_csv=vdyp_yields_csv,
+        output_dir=context.resolve_path(output_dir),
+    )
+    console.print(
+        "[green]mkrf plots rebuilt[/green] "
+        f"lmh={result.lmh_plot_count} "
+        f"fitdiag={result.fitdiag_plot_count} "
+        f"tipsy_vdyp={result.tipsy_vdyp_plot_count}"
+    )
+    console.print(f"strata_png: {result.strata_png}")
+    console.print(f"strata_pdf: {result.strata_pdf}")
+
+
+@app.command("mkrf-audit-bad-curves")
+def instance_mkrf_audit_bad_curves(
+    resultant_gdb: Path = typer.Option(
+        ...,
+        "--resultant-gdb",
+        exists=True,
+        dir_okay=True,
+        file_okay=True,
+        resolve_path=True,
+        help="Path to the upstream MKRF Resultant.gdb source surface.",
+    ),
+    vdyp_yields_csv: Path = typer.Option(
+        ...,
+        "--vdyp-yields-csv",
+        exists=True,
+        dir_okay=False,
+        file_okay=True,
+        resolve_path=True,
+        help="Path to the upstream MKRF VDYP_Yields.csv file.",
+    ),
+    assignment_csv: Path = typer.Option(
+        Path("data/model_input_bundle/stand_au_assignment.csv"),
+        "--assignment-csv",
+        help="Instance-relative stand-to-AU assignment CSV.",
+    ),
+    selected_au_csv: Path = typer.Option(
+        Path("data/model_input_bundle/selected_au_table.csv"),
+        "--selected-au-csv",
+        help="Instance-relative selected-AU table CSV.",
+    ),
+    first_growth_curves_csv: Path = typer.Option(
+        Path("data/model_input_bundle/first_growth_au_curves.csv"),
+        "--first-growth-curves-csv",
+        help="Instance-relative AU-wise first-growth curves CSV.",
+    ),
+    output_dir: Path = typer.Option(
+        Path("data/model_input_bundle"),
+        "--output-dir",
+        help="Instance-relative output directory for bad-curve audit CSVs.",
+    ),
+    instance_root: Path | None = INSTANCE_ROOT_OPTION,
+) -> None:
+    """Audit suspicious MKRF first-growth curve cases against source-stand evidence."""
+    context = _resolve_cli_instance_context(instance_root=instance_root)
+    result = build_mkrf_bad_curve_audit(
+        resultant_gdb=resultant_gdb,
+        assignment_csv=context.resolve_path(assignment_csv),
+        selected_au_csv=context.resolve_path(selected_au_csv),
+        first_growth_curves_csv=context.resolve_path(first_growth_curves_csv),
+        vdyp_yields_csv=vdyp_yields_csv,
+        output_dir=context.resolve_path(output_dir),
+    )
+    console.print(
+        "[green]mkrf bad-curve audit built[/green] "
+        f"flagged_aus={result.flagged_au_count} "
+        f"selected_aus={result.total_selected_au_count}"
+    )
+    console.print(f"summary_csv: {result.summary_path}")
+    console.print(f"detail_csv: {result.detail_path}")
+
+
+@app.command("mkrf-build-managed-au-inputs")
+def instance_mkrf_build_managed_au_inputs(
+    resultant_gdb: Path = typer.Option(
+        ...,
+        "--resultant-gdb",
+        exists=True,
+        dir_okay=True,
+        file_okay=True,
+        resolve_path=True,
+        help="Path to the upstream MKRF Resultant.gdb source surface.",
+    ),
+    tipsy_rules_yaml: Path = typer.Option(
+        Path("config/tipsy/tsamkrf.yaml"),
+        "--tipsy-rules-yaml",
+        help="Instance-relative managed-rule YAML used for expert planting specs.",
+    ),
+    selected_au_csv: Path = typer.Option(
+        Path("data/model_input_bundle/selected_au_table.csv"),
+        "--selected-au-csv",
+        help="Instance-relative selected-AU table CSV.",
+    ),
+    assignment_csv: Path = typer.Option(
+        Path("data/model_input_bundle/stand_au_assignment.csv"),
+        "--assignment-csv",
+        help="Instance-relative stand-to-AU assignment CSV.",
+    ),
+    output_dir: Path = typer.Option(
+        Path("data/model_input_bundle"),
+        "--output-dir",
+        help="Instance-relative output directory for managed AU bundle artifacts.",
+    ),
+    instance_root: Path | None = INSTANCE_ROOT_OPTION,
+) -> None:
+    """Build the expert-rule managed AU bootstrap and BTC MSYT surfaces."""
+    context = _resolve_cli_instance_context(instance_root=instance_root)
+    result = build_mkrf_managed_au_input_bundle(
+        resultant_gdb=resultant_gdb,
+        selected_au_csv=context.resolve_path(selected_au_csv),
+        assignment_csv=context.resolve_path(assignment_csv),
+        tipsy_rules_yaml=context.resolve_path(tipsy_rules_yaml),
+        output_dir=context.resolve_path(output_dir),
+    )
+    console.print(
+        "[green]mkrf managed au inputs built[/green] "
+        f"selected_aus={result.selected_au_count} "
+        f"included_aus={result.included_au_count} "
+        f"unmatched_aus={result.unmatched_au_count} "
+        f"logging_origin_si={result.logging_origin_si_au_count} "
+        f"all_stands_fallback={result.all_stands_si_fallback_au_count}"
+    )
+    console.print(f"stand_origin_assignment: {result.stand_origin_assignment_path}")
+    console.print(f"bootstrap_table: {result.bootstrap_table_path}")
+    console.print(f"managed_au_msyt: {result.msyt_path}")
+
+
+@app.command("mkrf-build-managed-au-curves")
+def instance_mkrf_build_managed_au_curves(
+    bootstrap_csv: Path = typer.Option(
+        Path("data/model_input_bundle/managed_au_bootstrap_table.csv"),
+        "--bootstrap-csv",
+        help="Instance-relative managed AU bootstrap table CSV.",
+    ),
+    msyt_csv: Path = typer.Option(
+        Path("data/model_input_bundle/managed_au_msyt.csv"),
+        "--msyt-csv",
+        help="Instance-relative managed AU BTC MSYT.csv input.",
+    ),
+    output_dir: Path = typer.Option(
+        Path("data/model_input_bundle"),
+        "--output-dir",
+        help="Instance-relative output directory for managed AU BTC artifacts.",
+    ),
+    log_dir: Path = typer.Option(
+        Path("runtime/logs/managed_au_btc"),
+        "--log-dir",
+        help="Instance-relative output directory for BTC runtime logs.",
+    ),
+    run_id: str = typer.Option(
+        "mkrf_managed_au_curves",
+        "--run-id",
+        help="Run identifier for the managed AU BTC attempt.",
+    ),
+    btc_executable: Path | None = typer.Option(
+        None,
+        "--btc-executable",
+        exists=False,
+        resolve_path=True,
+        help="Optional explicit TIPSYbtc.exe path override.",
+        show_default=False,
+    ),
+    instance_root: Path | None = INSTANCE_ROOT_OPTION,
+) -> None:
+    """Attempt a BTC compile for the provisional managed AU lane."""
+    context = _resolve_cli_instance_context(instance_root=instance_root)
+    result = build_mkrf_managed_au_curves(
+        bootstrap_csv=context.resolve_path(bootstrap_csv),
+        msyt_csv=context.resolve_path(msyt_csv),
+        output_dir=context.resolve_path(output_dir),
+        log_dir=context.resolve_path(log_dir),
+        run_id=run_id,
+        executable_path=btc_executable,
+    )
+    color = "green" if result.status == "completed" else "yellow"
+    console.print(
+        f"[{color}]mkrf managed au btc attempt {result.status}[/{color}] "
+        f"included_aus={result.included_au_count} curve_aus={result.curve_au_count}"
+    )
+    console.print(f"manifest: {result.manifest_path}")
+    if result.curves_path is not None:
+        console.print(f"managed_au_curves: {result.curves_path}")
+
+
+@app.command("mkrf-init-runtime-package")
+def instance_mkrf_init_runtime_package(
+    package_root: Path = typer.Option(
+        Path("models/mkrf_patchworks_model"),
+        "--package-root",
+        help="Instance-relative canonical MKRF runtime-package root.",
+    ),
+    selected_au_csv: Path = typer.Option(
+        Path("data/model_input_bundle/selected_au_table.csv"),
+        "--selected-au-csv",
+        help="Instance-relative selected-AU table CSV.",
+    ),
+    stand_origin_assignment_csv: Path = typer.Option(
+        Path("data/model_input_bundle/stand_origin_assignment.csv"),
+        "--stand-origin-assignment-csv",
+        help="Instance-relative stand-to-rebuild-AU assignment CSV.",
+    ),
+    stand_au_assignment_csv: Path = typer.Option(
+        Path("data/model_input_bundle/stand_au_assignment.csv"),
+        "--stand-au-assignment-csv",
+        help="Instance-relative stand-to-AU/species-share assignment CSV.",
+    ),
+    managed_bootstrap_csv: Path = typer.Option(
+        Path("data/model_input_bundle/managed_au_bootstrap_table.csv"),
+        "--managed-bootstrap-csv",
+        help="Instance-relative managed AU bootstrap/species-composition CSV.",
+    ),
+    first_growth_curves_csv: Path = typer.Option(
+        Path("data/model_input_bundle/first_growth_au_curves.csv"),
+        "--first-growth-curves-csv",
+        help="Instance-relative AU-wise first-growth curves CSV.",
+    ),
+    first_growth_diagnostics_csv: Path = typer.Option(
+        Path("data/model_input_bundle/first_growth_au_fit_diagnostics.csv"),
+        "--first-growth-diagnostics-csv",
+        help="Instance-relative AU-wise first-growth diagnostics CSV.",
+    ),
+    managed_curves_csv: Path = typer.Option(
+        Path("data/model_input_bundle/managed_au_curves.csv"),
+        "--managed-curves-csv",
+        help="Instance-relative managed AU curves CSV.",
+    ),
+    managed_run_manifest_json: Path = typer.Option(
+        Path("data/model_input_bundle/managed_au_run_manifest.json"),
+        "--managed-run-manifest-json",
+        help="Instance-relative managed AU run manifest JSON.",
+    ),
+    bad_curve_audit_summary_csv: Path = typer.Option(
+        Path("data/model_input_bundle/bad_curve_audit_summary.csv"),
+        "--bad-curve-audit-summary-csv",
+        help="Instance-relative bad-curve audit summary CSV.",
+    ),
+    instance_root: Path | None = INSTANCE_ROOT_OPTION,
+) -> None:
+    """Initialize the canonical MKRF runtime-package root and lineage manifest."""
+    context = _resolve_cli_instance_context(instance_root=instance_root)
+    result = initialize_mkrf_runtime_package(
+        package_root=context.resolve_path(package_root),
+        selected_au_csv=context.resolve_path(selected_au_csv),
+        stand_origin_assignment_csv=context.resolve_path(stand_origin_assignment_csv),
+        stand_au_assignment_csv=context.resolve_path(stand_au_assignment_csv),
+        managed_bootstrap_csv=context.resolve_path(managed_bootstrap_csv),
+        first_growth_curves_csv=context.resolve_path(first_growth_curves_csv),
+        first_growth_diagnostics_csv=context.resolve_path(first_growth_diagnostics_csv),
+        managed_curves_csv=context.resolve_path(managed_curves_csv),
+        managed_run_manifest_json=context.resolve_path(managed_run_manifest_json),
+        bad_curve_audit_summary_csv=context.resolve_path(bad_curve_audit_summary_csv),
+    )
+    console.print(
+        "[green]mkrf runtime package initialized[/green] "
+        f"selected_aus={result.selected_au_count} "
+        f"first_growth_aus={result.first_growth_curve_au_count} "
+        f"managed_curve_aus={result.managed_curve_au_count} "
+        f"first_growth_missing_aus={result.first_growth_missing_au_count}"
+    )
+    console.print(f"package_root: {result.package_root}")
+    console.print(f"manifest: {result.manifest_path}")
+    console.print(f"curve_status_csv: {result.curve_status_path}")
+    console.print(
+        f"analysis_au_runtime_status_csv: {result.analysis_au_runtime_status_path}"
+    )
+    console.print(f"analysis_au_curve_refs_csv: {result.analysis_au_curve_refs_path}")
+    console.print(f"runtime_species_share_audit_csv: {result.species_share_audit_path}")
+    console.print(f"analysis_pin: {result.analysis_pin_path}")
+    console.print(f"headless_runtime_common_bsh: {result.headless_runtime_common_path}")
+    console.print(f"flow_targets_bsh: {result.flow_targets_script_path}")
+    console.print(f"xml_contract: {result.xml_contract_path}")
+    console.print(f"xml_curve_bank: {result.xml_curve_bank_path}")
+    console.print(f"forestmodel_xml: {result.forestmodel_xml_path}")
+
+
+@app.command("mkrf-audit-runtime-sanity")
+def instance_mkrf_audit_runtime_sanity(
+    package_root: Path = typer.Option(
+        Path("models/mkrf_patchworks_model"),
+        "--package-root",
+        help="Instance-relative canonical MKRF runtime-package root.",
+    ),
+    stage_dir: Path = typer.Option(
+        ...,
+        "--stage-dir",
+        exists=True,
+        dir_okay=True,
+        file_okay=False,
+        resolve_path=True,
+        help="Absolute or repo-relative saved headless stage directory to audit.",
+    ),
+    instance_root: Path | None = INSTANCE_ROOT_OPTION,
+) -> None:
+    """Audit canonical MKRF runtime signal against published species-share sources."""
+    context = _resolve_cli_instance_context(instance_root=instance_root)
+    result = audit_mkrf_runtime_sanity(
+        package_root=context.resolve_path(package_root),
+        stage_dir=stage_dir.resolve(),
+    )
+    color = "green" if result.failure_count == 0 else "yellow"
+    console.print(
+        f"[{color}]mkrf runtime sanity audit complete[/{color}] "
+        f"rows={result.row_count} failures={result.failure_count}"
+    )
+    console.print(f"stage_dir: {result.stage_dir}")
+    console.print(f"audit_csv: {result.audit_csv_path}")
+    console.print(f"summary_json: {result.summary_json_path}")
+
+
+@app.command("mkrf-publish-runtime-spatial")
+def instance_mkrf_publish_runtime_spatial(
+    resultant_gdb: Path = typer.Option(
+        ...,
+        "--resultant-gdb",
+        exists=True,
+        dir_okay=True,
+        file_okay=True,
+        resolve_path=True,
+        help="Path to the upstream MKRF Resultant.gdb source surface.",
+    ),
+    package_root: Path = typer.Option(
+        Path("models/mkrf_patchworks_model"),
+        "--package-root",
+        help="Instance-relative canonical MKRF runtime-package root.",
+    ),
+    instance_root: Path | None = INSTANCE_ROOT_OPTION,
+) -> None:
+    """Publish canonical MKRF runtime fragments from Resultant.gdb."""
+    context = _resolve_cli_instance_context(instance_root=instance_root)
+    result = publish_mkrf_runtime_spatial_handoff(
+        resultant_gdb=resultant_gdb,
+        package_root=context.resolve_path(package_root),
+    )
+    console.print(
+        "[green]mkrf runtime spatial published[/green] "
+        f"source_features={result.source_feature_count} "
+        f"published_features={result.published_feature_count} "
+        f"excluded_features={result.excluded_feature_count}"
+    )
+    console.print(f"fragments: {result.fragments_path}")
+    console.print(f"manifest: {result.manifest_path}")

--- a/src/mkrf_femic/pipeline/__init__.py
+++ b/src/mkrf_femic/pipeline/__init__.py
@@ -1,0 +1,1 @@
+"""MKRF pipeline helpers."""

--- a/src/mkrf_femic/pipeline/mkrf_au.py
+++ b/src/mkrf_femic/pipeline/mkrf_au.py
@@ -1,0 +1,339 @@
+"""MKRF-specific AU table and stand-assignment builders."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+
+_SPECIES_SLOT_COUNT = 6
+_MKRF_AU_AGGREGATION_TARGETS: dict[str, str] = {
+    "cwh_vm_2_ba_hw": "cwh_vm_2_hw_ba",
+    "cwh_dm_x_dr_mb": "cwh_dm_x_dr_act",
+    "cwh_dm_x_cw_dr": "cwh_dm_x_dr_cw",
+    "cwh_vm_1_ba_hw": "cwh_vm_1_hw_ba",
+    "cwh_vm_1_fdc_hw": "cwh_vm_1_fdc_x",
+}
+
+
+def parse_mkrf_bec(value: object) -> tuple[str, str, str]:
+    """Split legacy MKRF BEC code into zone, subzone, and variant."""
+    text = "" if value is None else str(value).strip()
+    if not text or text.lower() == "nan":
+        return ("x", "x", "x")
+    zone = text[:3].lower() or "x"
+    rest = text[3:]
+    boundary = 0
+    while boundary < len(rest) and rest[boundary].isalpha():
+        boundary += 1
+    subzone = (rest[:boundary] or "x").lower()
+    variant = (rest[boundary:] or "x").lower()
+    return (zone, subzone, variant)
+
+
+@dataclass(frozen=True)
+class OrderedSpeciesPair:
+    """Ordered top-two species result for one source row."""
+
+    leading_species_1: str
+    leading_species_2: str
+    leading_species_1_share: float
+    leading_species_2_share: float
+    species_count: int
+    tie_break_used: bool
+
+
+def ordered_top_two_species(row: Any) -> OrderedSpeciesPair:
+    """Return ordered top-two species using descending share, then lexical tie-break."""
+    merged: dict[str, float] = {}
+    for idx in range(1, _SPECIES_SLOT_COUNT + 1):
+        species = row.get(f"TCL_1_TSP_{idx}_TREE_SPECIES_CODE")
+        species_text = "" if species is None else str(species).strip().lower()
+        if not species_text or species_text == "nan":
+            continue
+        raw_share = row.get(f"TCL_1_TSP_{idx}_SPECIES_PCT")
+        try:
+            share = float(raw_share)
+        except (TypeError, ValueError):
+            share = 0.0
+        if not math.isfinite(share) or share <= 0.0:
+            continue
+        merged[species_text] = merged.get(species_text, 0.0) + share
+
+    if not merged:
+        return OrderedSpeciesPair("x", "x", 0.0, 0.0, 0, False)
+
+    ranked = sorted(merged.items(), key=lambda item: (-item[1], item[0]))
+    share_counts: dict[float, int] = {}
+    for _, share in ranked:
+        share_counts[share] = share_counts.get(share, 0) + 1
+    top_two = ranked[:2]
+    tie_break_used = any(share_counts[share] > 1 for _, share in top_two)
+
+    lead_1, share_1 = ranked[0]
+    if len(ranked) > 1:
+        lead_2, share_2 = ranked[1]
+    else:
+        lead_2, share_2 = "x", 0.0
+
+    return OrderedSpeciesPair(
+        leading_species_1=lead_1,
+        leading_species_2=lead_2,
+        leading_species_1_share=float(share_1),
+        leading_species_2_share=float(share_2),
+        species_count=len(ranked),
+        tie_break_used=tie_break_used,
+    )
+
+
+def annotate_mkrf_au_keys(source_table: pd.DataFrame) -> pd.DataFrame:
+    """Annotate MKRF source rows with canonical AU-key fields."""
+    table = source_table.copy()
+
+    bec_parts = table["BEC"].apply(parse_mkrf_bec)
+    table[["bec_zone", "bec_subzone", "bec_variant"]] = pd.DataFrame(
+        bec_parts.tolist(),
+        index=table.index,
+    )
+
+    species_pairs = table.apply(ordered_top_two_species, axis=1)
+    species_frame = pd.DataFrame(
+        [
+            {
+                "leading_species_1": item.leading_species_1,
+                "leading_species_2": item.leading_species_2,
+                "leading_species_1_share": item.leading_species_1_share,
+                "leading_species_2_share": item.leading_species_2_share,
+                "species_count": item.species_count,
+                "tie_break_used": item.tie_break_used,
+            }
+            for item in species_pairs
+        ],
+        index=table.index,
+    )
+    table = pd.concat([table, species_frame], axis=1)
+
+    table["au_id"] = (
+        table["bec_zone"].astype(str)
+        + "_"
+        + table["bec_subzone"].astype(str)
+        + "_"
+        + table["bec_variant"].astype(str)
+        + "_"
+        + table["leading_species_1"].astype(str)
+        + "_"
+        + table["leading_species_2"].astype(str)
+    )
+    table["raw_au_id"] = table["au_id"]
+    table["au_id"] = table["raw_au_id"].map(
+        lambda value: _MKRF_AU_AGGREGATION_TARGETS.get(str(value), str(value))
+    )
+    table["au_aggregation_target"] = table["au_id"]
+    table["au_aggregation_applied"] = table["raw_au_id"] != table["au_id"]
+    return table
+
+
+def build_mkrf_assignment_rows(source_table: pd.DataFrame) -> pd.DataFrame:
+    """Build fragment-level MKRF assignment rows from source geometry rows."""
+    table = annotate_mkrf_au_keys(source_table)
+    shape_area = (
+        table["Shape_Area"]
+        if "Shape_Area" in table.columns
+        else pd.Series(0.0, index=table.index)
+    )
+
+    assignment = pd.DataFrame(
+        {
+            "source_feature_class": "resultant",
+            "res_key": table["RES_KEY"].astype(int),
+            "forest_cover_id": table["FOREST_COVER_ID"],
+            "bec": table["BEC"].astype(str),
+            "bec_zone": table["bec_zone"],
+            "bec_subzone": table["bec_subzone"],
+            "bec_variant": table["bec_variant"],
+            "leading_species_1": table["leading_species_1"],
+            "leading_species_2": table["leading_species_2"],
+            "leading_species_1_share": table["leading_species_1_share"],
+            "leading_species_2_share": table["leading_species_2_share"],
+            "species_count": table["species_count"].astype(int),
+            "tie_break_used": table["tie_break_used"].astype(bool),
+            "shape_area_ha": (
+                pd.to_numeric(shape_area, errors="coerce").fillna(0.0) / 10000.0
+            ),
+            "raw_au_id": table["raw_au_id"],
+            "au_id": table["au_id"],
+            "au_aggregation_applied": table["au_aggregation_applied"].astype(bool),
+            "au_aggregation_target": table["au_aggregation_target"],
+            "assignment_status": "assigned",
+        }
+    ).sort_values(["au_id", "res_key"], kind="stable")
+    return assignment.reset_index(drop=True)
+
+
+def build_mkrf_au_tables(
+    source_table: pd.DataFrame,
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Build canonical MKRF AU and stand-assignment tables from Resultant records."""
+    table = source_table.copy()
+    if "CONTCLAS" in table.columns:
+        table = table.loc[table["CONTCLAS"] != "X"].copy()
+
+    assignment = build_mkrf_assignment_rows(table)
+    canonical_parts = assignment["au_id"].astype(str).str.split("_", expand=True)
+    if canonical_parts.shape[1] != 5:
+        raise ValueError("MKRF AU aggregation produced non-canonical AU identifiers.")
+    assignment = assignment.copy()
+    assignment[
+        [
+            "au_bec_zone",
+            "au_bec_subzone",
+            "au_bec_variant",
+            "au_species_1",
+            "au_species_2",
+        ]
+    ] = canonical_parts
+    au_table = (
+        assignment.groupby(
+            [
+                "au_id",
+                "au_bec_zone",
+                "au_bec_subzone",
+                "au_bec_variant",
+                "au_species_1",
+                "au_species_2",
+            ],
+            as_index=False,
+            sort=True,
+        )
+        .agg(
+            stand_count=("res_key", "count"),
+            tie_break_record_count=("tie_break_used", "sum"),
+        )
+        .sort_values("au_id", kind="stable")
+        .rename(
+            columns={
+                "au_bec_zone": "bec_zone",
+                "au_bec_subzone": "bec_subzone",
+                "au_bec_variant": "bec_variant",
+                "au_species_1": "leading_species_1",
+                "au_species_2": "leading_species_2",
+            }
+        )
+    )
+
+    au_table["tie_break_record_count"] = au_table["tie_break_record_count"].astype(int)
+    au_table["stand_count"] = au_table["stand_count"].astype(int)
+    return au_table.reset_index(drop=True), assignment
+
+
+def build_mkrf_au_aggregation_audit(assignment: pd.DataFrame) -> pd.DataFrame:
+    """Summarize raw-to-canonical AU aggregation decisions."""
+    required = {"raw_au_id", "au_id", "shape_area_ha", "forest_cover_id", "res_key"}
+    missing = sorted(required - set(assignment.columns))
+    if missing:
+        raise ValueError(
+            "MKRF assignment table missing aggregation audit columns: "
+            + ", ".join(missing)
+        )
+    audit = (
+        assignment.assign(
+            raw_au_id=lambda df: df["raw_au_id"].astype(str),
+            au_id=lambda df: df["au_id"].astype(str),
+            shape_area_ha=lambda df: pd.to_numeric(
+                df["shape_area_ha"], errors="coerce"
+            ).fillna(0.0),
+            forest_cover_id=lambda df: pd.to_numeric(
+                df["forest_cover_id"], errors="coerce"
+            ),
+        )
+        .groupby(["raw_au_id", "au_id"], as_index=False, dropna=False)
+        .agg(
+            source_fragment_count=("res_key", "count"),
+            forest_cover_id_count=("forest_cover_id", "nunique"),
+            covered_area_ha=("shape_area_ha", "sum"),
+        )
+        .sort_values(["au_id", "raw_au_id"], kind="stable")
+        .reset_index(drop=True)
+    )
+    audit["was_aggregated"] = audit["raw_au_id"] != audit["au_id"]
+    total_area = float(audit["covered_area_ha"].sum())
+    audit["covered_area_share"] = (
+        audit["covered_area_ha"] / total_area if total_area > 0.0 else 0.0
+    )
+    target_area = audit.groupby("au_id")["covered_area_ha"].transform("sum")
+    audit["target_area_ha"] = target_area
+    audit["raw_share_of_target_area"] = np.where(
+        target_area.gt(0.0),
+        audit["covered_area_ha"] / target_area,
+        0.0,
+    )
+    return audit[
+        [
+            "raw_au_id",
+            "au_id",
+            "was_aggregated",
+            "source_fragment_count",
+            "forest_cover_id_count",
+            "covered_area_ha",
+            "covered_area_share",
+            "target_area_ha",
+            "raw_share_of_target_area",
+        ]
+    ]
+
+
+def build_mkrf_selected_au_table(
+    au_table: pd.DataFrame,
+    assignment: pd.DataFrame,
+    *,
+    target_coverage: float = 0.95,
+) -> pd.DataFrame:
+    """Select the smallest top-N AU subset reaching the target covered-area share."""
+    if not 0.0 < float(target_coverage) <= 1.0:
+        raise ValueError("target_coverage must be in the interval (0, 1].")
+
+    if au_table.empty:
+        selected = au_table.copy()
+        selected["covered_area_ha"] = pd.Series(dtype=float)
+        selected["covered_area_share"] = pd.Series(dtype=float)
+        selected["cumulative_covered_area_share"] = pd.Series(dtype=float)
+        selected["selected_rank"] = pd.Series(dtype=int)
+        selected["target_coverage"] = float(target_coverage)
+        return selected
+
+    area_by_au = (
+        assignment.groupby("au_id", as_index=True)["shape_area_ha"]
+        .sum()
+        .rename("covered_area_ha")
+    )
+    selected = au_table.merge(area_by_au, on="au_id", how="left")
+    selected["covered_area_ha"] = pd.to_numeric(
+        selected["covered_area_ha"], errors="coerce"
+    ).fillna(0.0)
+    selected = selected.sort_values(
+        ["covered_area_ha", "au_id"],
+        ascending=[False, True],
+        kind="stable",
+    ).reset_index(drop=True)
+
+    total_area = float(selected["covered_area_ha"].sum())
+    if total_area <= 0.0:
+        selected["covered_area_share"] = 0.0
+        selected["cumulative_covered_area_share"] = 0.0
+        selected["selected_rank"] = pd.Series(range(1, len(selected) + 1), dtype=int)
+        selected["target_coverage"] = float(target_coverage)
+        return selected.iloc[0:0].copy()
+
+    selected["covered_area_share"] = selected["covered_area_ha"] / total_area
+    selected["cumulative_covered_area_share"] = selected["covered_area_share"].cumsum()
+    cutoff_idx = (
+        selected["cumulative_covered_area_share"].ge(float(target_coverage)).idxmax()
+    )
+    selected = selected.iloc[: cutoff_idx + 1].copy()
+    selected["selected_rank"] = pd.Series(range(1, len(selected) + 1), dtype=int)
+    selected["target_coverage"] = float(target_coverage)
+    return selected.reset_index(drop=True)

--- a/src/mkrf_femic/pipeline/mkrf_first_growth.py
+++ b/src/mkrf_femic/pipeline/mkrf_first_growth.py
@@ -1,0 +1,380 @@
+"""MKRF AU-wise first-growth curve synthesis from stand-level VDYP evidence."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+import math
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from femic.pipeline.au_first_growth import select_au_first_growth_curve
+from mkrf_femic.pipeline.mkrf_au import build_mkrf_assignment_rows
+from femic.pipeline.tsa import build_stratum_lexmatch_alias_map
+from femic.pipeline.vdyp_curves import process_vdyp_out
+
+
+_MIN_FIRST_GROWTH_AGE = 80.0
+_MIN_FIRST_GROWTH_SOURCE_STANDS = 2
+
+
+@dataclass(frozen=True)
+class StandAssignmentCollapse:
+    """Deterministic stand-level AU assignment with ambiguity diagnostics."""
+
+    forest_cover_id: int
+    au_id: str
+    assignment_weight_basis: str
+    fragment_record_count: int
+    candidate_au_count: int
+    dominant_weight: float
+    total_weight: float
+    weight_share: float
+    tie_break_used: bool
+
+
+def collapse_stand_assignments(assignment: pd.DataFrame) -> pd.DataFrame:
+    """Collapse fragment-level assignment rows to one deterministic AU per stand."""
+    table = assignment.copy()
+    weight_col = "shape_area_ha" if "shape_area_ha" in table.columns else None
+    weight_basis = (
+        "shape_area_ha" if weight_col is not None else "fragment_record_count"
+    )
+    if weight_col is None:
+        table["_weight"] = 1.0
+    else:
+        numeric = pd.to_numeric(table[weight_col], errors="coerce").fillna(0.0)
+        table["_weight"] = numeric.astype(float)
+
+    grouped = (
+        table.groupby(["forest_cover_id", "au_id"], as_index=False, sort=True)
+        .agg(
+            fragment_record_count=("res_key", "count"),
+            total_weight=("_weight", "sum"),
+        )
+        .sort_values(
+            ["forest_cover_id", "total_weight", "fragment_record_count", "au_id"],
+            ascending=[True, False, False, True],
+            kind="stable",
+        )
+    )
+
+    rows: list[StandAssignmentCollapse] = []
+    for forest_cover_id, stand_rows in grouped.groupby("forest_cover_id", sort=True):
+        ordered = stand_rows.reset_index(drop=True)
+        dominant = ordered.iloc[0]
+        total_weight = float(ordered["total_weight"].sum())
+        top_weight = float(dominant["total_weight"])
+        top_count = int(dominant["fragment_record_count"])
+        candidate_count = int(len(ordered))
+        tie_break_used = False
+        if candidate_count > 1:
+            same_weight = ordered["total_weight"] == top_weight
+            same_count = ordered["fragment_record_count"] == top_count
+            tie_break_used = int((same_weight & same_count).sum()) > 1
+        rows.append(
+            StandAssignmentCollapse(
+                forest_cover_id=int(forest_cover_id),
+                au_id=str(dominant["au_id"]),
+                assignment_weight_basis=weight_basis,
+                fragment_record_count=top_count,
+                candidate_au_count=candidate_count,
+                dominant_weight=top_weight,
+                total_weight=total_weight,
+                weight_share=(top_weight / total_weight) if total_weight > 0.0 else 0.0,
+                tie_break_used=tie_break_used,
+            )
+        )
+
+    return pd.DataFrame(
+        [
+            {
+                "forest_cover_id": row.forest_cover_id,
+                "au_id": row.au_id,
+                "assignment_weight_basis": row.assignment_weight_basis,
+                "fragment_record_count": row.fragment_record_count,
+                "candidate_au_count": row.candidate_au_count,
+                "dominant_weight": row.dominant_weight,
+                "total_weight": row.total_weight,
+                "weight_share": row.weight_share,
+                "tie_break_used": row.tie_break_used,
+            }
+            for row in rows
+        ]
+    ).sort_values(["au_id", "forest_cover_id"], kind="stable")
+
+
+def _build_feature_tables(vdyp_yields: pd.DataFrame) -> dict[int, pd.DataFrame]:
+    feature_tables: dict[int, pd.DataFrame] = {}
+    for feature_id, feature_rows in vdyp_yields.groupby("FEATURE_ID", sort=True):
+        ordered = feature_rows.sort_values("PRJ_TOTAL_AGE", kind="stable")
+        feature_tables[int(feature_id)] = (
+            ordered.rename(
+                columns={
+                    "PRJ_TOTAL_AGE": "Age",
+                    "PRJ_VOL_DWB": "Vdwb",
+                }
+            )[["Age", "Vdwb"]]
+            .set_index("Age")
+            .copy()
+        )
+    return feature_tables
+
+
+def _build_au_lexmatch_alias_map(
+    *,
+    selected_assignment: pd.DataFrame,
+    candidate_assignment: pd.DataFrame,
+    levenshtein_fn: Callable[[str, str], int],
+) -> dict[str, str]:
+    selected_area_col = (
+        "dominant_weight"
+        if "dominant_weight" in selected_assignment.columns
+        else "shape_area_ha"
+    )
+    selected_area = (
+        selected_assignment.groupby("au_id", as_index=True)[selected_area_col]
+        .sum()
+        .sort_index()
+    )
+    candidate_area = (
+        candidate_assignment.groupby("au_id", as_index=True)["shape_area_ha"]
+        .sum()
+        .sort_index()
+    )
+    f_table = pd.concat(
+        [
+            pd.DataFrame(
+                {
+                    "stratum": selected_area.index,
+                    "stratum_lexmatch": selected_area.index,
+                    "totalarea_p": selected_area.astype(float),
+                }
+            ).set_index("stratum"),
+            pd.DataFrame(
+                {
+                    "stratum": candidate_area.index,
+                    "stratum_lexmatch": candidate_area.index,
+                    "totalarea_p": candidate_area.astype(float),
+                }
+            ).set_index("stratum"),
+        ],
+        axis=0,
+    )
+    return build_stratum_lexmatch_alias_map(
+        f_table=f_table,
+        stratum_col="stratum",
+        selected_strata_codes=list(selected_area.index),
+        levenshtein_fn=levenshtein_fn,
+    )
+
+
+def _expand_stand_assignment_with_lexmatch(
+    *,
+    stand_assignment: pd.DataFrame,
+    source_table: pd.DataFrame,
+    unmatched_feature_ids: set[int],
+    levenshtein_fn: Callable[[str, str], int],
+) -> pd.DataFrame:
+    candidate_rows = source_table.loc[
+        source_table["FOREST_COVER_ID"].isin(sorted(unmatched_feature_ids))
+    ].copy()
+    if candidate_rows.empty:
+        return stand_assignment
+
+    candidate_assignment = build_mkrf_assignment_rows(candidate_rows)
+    if candidate_assignment.empty:
+        return stand_assignment
+
+    candidate_assignment["assignment_status"] = "lexmatch_candidate"
+    collapsed_candidates = collapse_stand_assignments(candidate_assignment)
+    collapsed_candidates["source_au_id"] = collapsed_candidates["au_id"]
+    alias_map = _build_au_lexmatch_alias_map(
+        selected_assignment=stand_assignment,
+        candidate_assignment=candidate_assignment,
+        levenshtein_fn=levenshtein_fn,
+    )
+    collapsed_candidates["au_id"] = [
+        alias_map.get(source_au_id, source_au_id)
+        for source_au_id in collapsed_candidates["source_au_id"]
+    ]
+    collapsed_candidates["assignment_status"] = "lexmatch_assigned"
+    collapsed_candidates["lexmatch_alias_used"] = [
+        alias_map.get(source_au_id, source_au_id) != source_au_id
+        for source_au_id in collapsed_candidates["source_au_id"]
+    ]
+    combined = pd.concat(
+        [
+            stand_assignment.assign(
+                assignment_status="assigned",
+                lexmatch_alias_used=False,
+            ),
+            collapsed_candidates,
+        ],
+        ignore_index=True,
+        sort=False,
+    )
+    return combined.sort_values(
+        ["au_id", "forest_cover_id"], kind="stable"
+    ).reset_index(drop=True)
+
+
+def _resolve_eligible_first_growth_feature_ids(
+    *,
+    vdyp_yields: pd.DataFrame,
+    source_table: pd.DataFrame | None,
+    min_first_growth_age: float,
+) -> set[int]:
+    vdyp_feature_ids = set(
+        pd.to_numeric(vdyp_yields["FEATURE_ID"], errors="coerce").dropna().astype(int)
+    )
+    if source_table is None or "AGE_2020" not in source_table.columns:
+        return vdyp_feature_ids
+    source_age = source_table.copy()
+    source_age["forest_cover_id"] = pd.to_numeric(
+        source_age["FOREST_COVER_ID"], errors="coerce"
+    )
+    source_age["age_2020"] = pd.to_numeric(source_age["AGE_2020"], errors="coerce")
+    eligible = source_age.loc[
+        source_age["forest_cover_id"].notna()
+        & source_age["age_2020"].ge(float(min_first_growth_age)),
+        "forest_cover_id",
+    ]
+    return vdyp_feature_ids & set(eligible.astype(int))
+
+
+def build_mkrf_first_growth_curves(
+    *,
+    vdyp_yields: pd.DataFrame,
+    assignment: pd.DataFrame,
+    source_table: pd.DataFrame | None = None,
+    levenshtein_fn: Callable[[str, str], int] | None = None,
+    process_vdyp_out_fn: Callable[
+        ..., tuple[np.ndarray, np.ndarray]
+    ] = process_vdyp_out,
+    min_first_growth_age: float = _MIN_FIRST_GROWTH_AGE,
+    min_source_stands: int = _MIN_FIRST_GROWTH_SOURCE_STANDS,
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Build AU-wise first-growth curves and fit diagnostics from VDYP stand evidence."""
+    stand_assignment = collapse_stand_assignments(assignment)
+    eligible_feature_ids = _resolve_eligible_first_growth_feature_ids(
+        vdyp_yields=vdyp_yields,
+        source_table=source_table,
+        min_first_growth_age=min_first_growth_age,
+    )
+    stand_assignment = stand_assignment.loc[
+        pd.to_numeric(stand_assignment["forest_cover_id"], errors="coerce")
+        .fillna(-1)
+        .astype(int)
+        .isin(eligible_feature_ids)
+    ].copy()
+    assigned_feature_ids = set(
+        pd.to_numeric(stand_assignment["forest_cover_id"], errors="coerce")
+        .dropna()
+        .astype(int)
+    )
+    unmatched_feature_ids = eligible_feature_ids - assigned_feature_ids
+    if unmatched_feature_ids:
+        if source_table is None:
+            raise ValueError(
+                "source_table is required when VDYP source stands do not match the "
+                "published assignment bundle"
+            )
+        if levenshtein_fn is None:
+            distance_mod = __import__("distance")
+            levenshtein_fn = distance_mod.levenshtein
+        stand_assignment = _expand_stand_assignment_with_lexmatch(
+            stand_assignment=stand_assignment,
+            source_table=source_table,
+            unmatched_feature_ids=unmatched_feature_ids,
+            levenshtein_fn=levenshtein_fn,
+        )
+
+    joined = vdyp_yields.merge(
+        stand_assignment[["forest_cover_id", "au_id"]],
+        left_on="FEATURE_ID",
+        right_on="forest_cover_id",
+        how="inner",
+    )
+    feature_tables = _build_feature_tables(joined)
+
+    curve_rows: list[dict[str, Any]] = []
+    diagnostic_rows: list[dict[str, Any]] = []
+
+    for au_id, au_rows in joined.groupby("au_id", sort=True):
+        feature_ids = sorted({int(v) for v in au_rows["FEATURE_ID"].tolist()})
+        assignment_rows = stand_assignment.loc[
+            stand_assignment["au_id"] == str(au_id)
+        ].copy()
+        ambiguous_count = int((assignment_rows["candidate_au_count"] > 1).sum())
+        tie_break_count = int(assignment_rows["tie_break_used"].astype(bool).sum())
+        assignment_status = assignment_rows.get(
+            "assignment_status",
+            pd.Series("assigned", index=assignment_rows.index),
+        )
+        lexmatch_used = assignment_rows.get(
+            "lexmatch_alias_used",
+            pd.Series(False, index=assignment_rows.index),
+        )
+        lexmatch_count = int(assignment_status.eq("lexmatch_assigned").sum())
+        lexmatch_alias_count = int(lexmatch_used.astype(bool).sum())
+        sparse_warning = len(feature_ids) < 5
+        vdyp_out = {
+            feature_id: feature_tables[feature_id] for feature_id in feature_ids
+        }
+        selection = select_au_first_growth_curve(
+            vdyp_out=vdyp_out,
+            min_source_stands=min_source_stands,
+        )
+        binned = selection.binned
+        x_curve = selection.x_curve
+        y_curve = selection.y_curve
+        metrics = selection.metrics
+        selected_path = selection.selected_path
+        accepted = selection.accepted
+
+        for age, volume in zip(
+            np.asarray(x_curve, dtype=float), np.asarray(y_curve, dtype=float)
+        ):
+            if not math.isfinite(float(volume)) or float(volume) <= 0.0:
+                continue
+            curve_rows.append(
+                {
+                    "au_id": str(au_id),
+                    "age": int(age),
+                    "volume": round(float(volume), 6),
+                }
+            )
+
+        diagnostic_rows.append(
+            {
+                "au_id": str(au_id),
+                "source_stand_count": len(feature_ids),
+                "source_row_count": int(len(au_rows)),
+                "observed_bin_count": int(len(binned)),
+                "curve_point_count": int(sum(1 for y in y_curve if float(y) > 0.0)),
+                "age_min": int(au_rows["PRJ_TOTAL_AGE"].min()),
+                "age_max": int(au_rows["PRJ_TOTAL_AGE"].max()),
+                "assignment_weight_basis": assignment_rows[
+                    "assignment_weight_basis"
+                ].iloc[0],
+                "ambiguous_stand_count": ambiguous_count,
+                "tie_break_stand_count": tie_break_count,
+                "lexmatch_stand_count": lexmatch_count,
+                "lexmatch_alias_stand_count": lexmatch_alias_count,
+                "sparse_warning": sparse_warning,
+                "selected_path": selected_path,
+                "rmse": round(metrics["rmse"], 6),
+                "mape": round(metrics["mape"], 6),
+                "tail_rmse": round(metrics["tail_rmse"], 6),
+                "accepted": accepted,
+            }
+        )
+
+    curves = pd.DataFrame(curve_rows, columns=["au_id", "age", "volume"]).sort_values(
+        ["au_id", "age"], kind="stable"
+    )
+    diagnostics = pd.DataFrame(diagnostic_rows).sort_values("au_id", kind="stable")
+    return curves.reset_index(drop=True), diagnostics.reset_index(drop=True)

--- a/src/mkrf_femic/pipeline/mkrf_managed.py
+++ b/src/mkrf_femic/pipeline/mkrf_managed.py
@@ -1,0 +1,764 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+import numpy as np
+import pandas as pd
+import yaml
+
+from mkrf_femic.pipeline.mkrf_au import parse_mkrf_bec
+from mkrf_femic.pipeline.mkrf_first_growth import collapse_stand_assignments
+from femic.pipeline.tipsy import (
+    build_btc_msyt_input_table,
+    parse_btc_tsr_transposed_output,
+)
+
+_MANAGED_TIPSY_SPECIES_COLUMNS = ("BA", "CW", "DR", "FD", "HW", "PW", "SS", "YC")
+_DEFAULT_MANAGED_RULE_KEY = "families"
+
+
+def _portable_path_value(path: Path | str | None) -> str | None:
+    if path is None:
+        return None
+    candidate = Path(path)
+    try:
+        return os.path.relpath(candidate.resolve(), Path.cwd().resolve()).replace(
+            "\\", "/"
+        )
+    except Exception:
+        return candidate.name
+
+
+@dataclass(frozen=True)
+class ManagedSpeciesPayload:
+    species_1: str
+    species_2: str
+    species_3: str
+    species_4: str
+    species_5: str
+    pct_1: float
+    pct_2: float
+    pct_3: float
+    pct_4: float
+    pct_5: float
+
+
+@dataclass(frozen=True)
+class MkrfManagedRule:
+    family_id: str
+    bec_zone: str
+    bec_subzone: str
+    bec_variant: str
+    density_total: int
+    regen_delay: int
+    oaf1: float
+    oaf2: float
+    planted_percent: int
+    baseline_system: str
+    ct_eligible: bool
+    ct_target_age: int
+    ct_on_fire_origin: bool
+    species_mix: Mapping[str, float]
+    notes: str
+
+
+@dataclass(frozen=True)
+class MkrfManagedRuleConfig:
+    path: Path
+    fire_origin_min_age: float
+    hw_ingrowth_overlay: HwIngrowthOverlayConfig
+    rules: tuple[MkrfManagedRule, ...]
+
+
+@dataclass(frozen=True)
+class HwIngrowthOverlayConfig:
+    enabled: bool
+    landscape_default_pct: float
+    au_overrides_pct: Mapping[str, float]
+    stand_overrides_pct: Mapping[str, float]
+
+
+def build_mkrf_legacy_managed_au_table(
+    *,
+    man_si_by_au: pd.DataFrame,
+    tipsy_spp_comp: pd.DataFrame,
+) -> pd.DataFrame:
+    merged = man_si_by_au.merge(tipsy_spp_comp, on="AU", how="inner")
+    bec_parts = merged["BEC"].apply(parse_mkrf_bec)
+    merged[["bec_zone", "bec_subzone", "bec_variant"]] = pd.DataFrame(
+        bec_parts.tolist(),
+        index=merged.index,
+    )
+    species_pairs = merged.apply(_tipsy_species_pair, axis=1)
+    merged["leading_species_1"] = [pair[0] for pair in species_pairs]
+    merged["leading_species_2"] = [pair[1] for pair in species_pairs]
+    merged["legacy_candidate_au_id"] = (
+        merged["bec_zone"].astype(str)
+        + "_"
+        + merged["bec_subzone"].astype(str)
+        + "_"
+        + merged["bec_variant"].astype(str)
+        + "_"
+        + merged["leading_species_1"].astype(str)
+        + "_"
+        + merged["leading_species_2"].astype(str)
+    )
+    return merged
+
+
+def load_mkrf_managed_rule_config(path: Path) -> MkrfManagedRuleConfig:
+    payload = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    origin_rules = payload.get("origin_rules", {}) or {}
+    managed_defaults = payload.get("managed_defaults", {}) or {}
+    hw_ingrowth_overlay = _load_hw_ingrowth_overlay_config(
+        payload.get("hw_ingrowth_overlay", {}) or {},
+        path=path,
+    )
+    raw_rules = payload.get(_DEFAULT_MANAGED_RULE_KEY, {}) or {}
+    if not isinstance(raw_rules, Mapping) or not raw_rules:
+        raise ValueError(f"Managed rule config has no families: {path}")
+
+    fire_origin_min_age = float(origin_rules.get("fire_origin_min_age", 80.0))
+    defaults = {
+        "density_total": int(managed_defaults.get("density_total", 1500)),
+        "regen_delay": int(managed_defaults.get("regen_delay", 1)),
+        "oaf1": float(managed_defaults.get("oaf1", 1.0)),
+        "oaf2": float(managed_defaults.get("oaf2", 0.95)),
+        "planted_percent": int(managed_defaults.get("planted_percent", 100)),
+        "baseline_system": str(managed_defaults.get("baseline_system", "clearcut")),
+        "ct_eligible": bool(managed_defaults.get("ct_eligible", True)),
+        "ct_target_age": int(managed_defaults.get("ct_target_age", 40)),
+        "ct_on_fire_origin": bool(managed_defaults.get("ct_on_fire_origin", False)),
+    }
+
+    rules: list[MkrfManagedRule] = []
+    for family_id, raw_rule in raw_rules.items():
+        if not isinstance(raw_rule, Mapping):
+            raise ValueError(
+                f"Managed family {family_id!r} must be a mapping in {path}"
+            )
+        species_mix = raw_rule.get("species_mix", {}) or {}
+        if not isinstance(species_mix, Mapping) or not species_mix:
+            raise ValueError(
+                f"Managed family {family_id!r} is missing a non-empty species_mix in {path}"
+            )
+        normalized_mix: dict[str, float] = {}
+        for species, share in species_mix.items():
+            code = str(species).strip().upper()
+            if code not in _MANAGED_TIPSY_SPECIES_COLUMNS:
+                raise ValueError(
+                    f"Managed family {family_id!r} uses unsupported species code {code!r}"
+                )
+            normalized_mix[code] = float(share)
+        rules.append(
+            MkrfManagedRule(
+                family_id=str(family_id),
+                bec_zone=str(raw_rule.get("bec_zone", "")).strip().lower(),
+                bec_subzone=str(raw_rule.get("bec_subzone", "")).strip().lower(),
+                bec_variant=str(raw_rule.get("bec_variant", "")).strip().lower(),
+                density_total=int(
+                    raw_rule.get("density_total", defaults["density_total"])
+                ),
+                regen_delay=int(raw_rule.get("regen_delay", defaults["regen_delay"])),
+                oaf1=float(raw_rule.get("oaf1", defaults["oaf1"])),
+                oaf2=float(raw_rule.get("oaf2", defaults["oaf2"])),
+                planted_percent=int(
+                    raw_rule.get("planted_percent", defaults["planted_percent"])
+                ),
+                baseline_system=str(
+                    raw_rule.get("baseline_system", defaults["baseline_system"])
+                ),
+                ct_eligible=bool(raw_rule.get("ct_eligible", defaults["ct_eligible"])),
+                ct_target_age=int(
+                    raw_rule.get("ct_target_age", defaults["ct_target_age"])
+                ),
+                ct_on_fire_origin=bool(
+                    raw_rule.get(
+                        "ct_on_fire_origin",
+                        defaults["ct_on_fire_origin"],
+                    )
+                ),
+                species_mix=normalized_mix,
+                notes=str(raw_rule.get("notes", "")).strip(),
+            )
+        )
+    return MkrfManagedRuleConfig(
+        path=path,
+        fire_origin_min_age=fire_origin_min_age,
+        hw_ingrowth_overlay=hw_ingrowth_overlay,
+        rules=tuple(rules),
+    )
+
+
+def classify_mkrf_origin(
+    *,
+    age_2020: Any,
+    fire_origin_min_age: float = 80.0,
+) -> str:
+    age = pd.to_numeric(pd.Series([age_2020]), errors="coerce").iloc[0]
+    if pd.isna(age):
+        return "unknown"
+    if float(age) >= float(fire_origin_min_age):
+        return "fire_origin"
+    return "logging_origin"
+
+
+def build_mkrf_stand_origin_assignment(
+    *,
+    assignment: pd.DataFrame,
+    source_table: pd.DataFrame,
+    fire_origin_min_age: float = 80.0,
+) -> pd.DataFrame:
+    stand_assignment = collapse_stand_assignments(assignment)
+    assignment_context = (
+        assignment[
+            [
+                "au_id",
+                "bec_zone",
+                "bec_subzone",
+                "bec_variant",
+                "leading_species_1",
+                "leading_species_2",
+            ]
+        ]
+        .drop_duplicates(subset=["au_id"])
+        .copy()
+    )
+    source_subset = source_table[
+        [
+            "FOREST_COVER_ID",
+            "AGE_2020",
+            "TCL_1_ESTIMATED_SITE_INDEX",
+        ]
+    ].copy()
+    source_subset = source_subset.rename(
+        columns={
+            "FOREST_COVER_ID": "forest_cover_id",
+            "AGE_2020": "age_2020",
+            "TCL_1_ESTIMATED_SITE_INDEX": "site_index",
+        }
+    )
+    source_subset["forest_cover_id"] = pd.to_numeric(
+        source_subset["forest_cover_id"], errors="coerce"
+    )
+    source_subset["age_2020"] = pd.to_numeric(
+        source_subset["age_2020"], errors="coerce"
+    )
+    source_subset["site_index"] = pd.to_numeric(
+        source_subset["site_index"], errors="coerce"
+    )
+    stand_source = (
+        source_subset.dropna(subset=["forest_cover_id"])
+        .assign(forest_cover_id=lambda df: df["forest_cover_id"].astype(int))
+        .groupby("forest_cover_id", as_index=False, sort=True)
+        .agg(
+            age_2020=("age_2020", "median"),
+            site_index=("site_index", "median"),
+        )
+    )
+    origin_assignment = stand_assignment.merge(
+        assignment_context,
+        on="au_id",
+        how="left",
+        validate="many_to_one",
+    ).merge(
+        stand_source,
+        on="forest_cover_id",
+        how="left",
+        validate="one_to_one",
+    )
+    origin_assignment["origin_class"] = origin_assignment["age_2020"].map(
+        lambda value: classify_mkrf_origin(
+            age_2020=value,
+            fire_origin_min_age=fire_origin_min_age,
+        )
+    )
+    origin_assignment["fire_origin_min_age"] = float(fire_origin_min_age)
+    origin_assignment["is_fire_origin"] = origin_assignment["origin_class"].eq(
+        "fire_origin"
+    )
+    origin_assignment["is_logging_origin"] = origin_assignment["origin_class"].eq(
+        "logging_origin"
+    )
+    return origin_assignment.sort_values(
+        ["au_id", "forest_cover_id"],
+        kind="stable",
+    ).reset_index(drop=True)
+
+
+def build_mkrf_managed_au_bootstrap_table(
+    *,
+    selected_au_table: pd.DataFrame,
+    stand_origin_assignment: pd.DataFrame,
+    rule_config: MkrfManagedRuleConfig,
+) -> pd.DataFrame:
+    rows: list[dict[str, Any]] = []
+    ordered_selected = selected_au_table.sort_values(
+        ["selected_rank", "au_id"],
+        kind="stable",
+    )
+    for _, selected_row in ordered_selected.iterrows():
+        au_id = str(selected_row["au_id"])
+        rule = _match_managed_rule(
+            rule_config=rule_config,
+            bec_zone=str(selected_row["bec_zone"]),
+            bec_subzone=str(selected_row["bec_subzone"]),
+            bec_variant=str(selected_row["bec_variant"]),
+        )
+        support_rows = stand_origin_assignment.loc[
+            stand_origin_assignment["au_id"].astype(str) == au_id
+        ].copy()
+        logging_si = pd.to_numeric(
+            support_rows.loc[
+                support_rows["origin_class"].astype(str) == "logging_origin",
+                "site_index",
+            ],
+            errors="coerce",
+        ).dropna()
+        all_si = pd.to_numeric(support_rows["site_index"], errors="coerce").dropna()
+
+        if len(logging_si) > 0:
+            managed_si = float(logging_si.median())
+            si_source = "logging_origin_median"
+        elif len(all_si) > 0:
+            managed_si = float(all_si.median())
+            si_source = "all_stands_median"
+        else:
+            managed_si = float("nan")
+            si_source = "missing_site_index"
+
+        base_row = {
+            "au_id": au_id,
+            "selected_rank": int(selected_row["selected_rank"]),
+            "covered_area_ha": float(selected_row["covered_area_ha"]),
+            "bec_zone": str(selected_row["bec_zone"]),
+            "bec_subzone": str(selected_row["bec_subzone"]),
+            "bec_variant": str(selected_row["bec_variant"]),
+            "leading_species_1": str(selected_row["leading_species_1"]),
+            "leading_species_2": str(selected_row["leading_species_2"]),
+            "managed_curve_id": 60000 + int(selected_row["selected_rank"]),
+            "managed_rule_source": _portable_path_value(rule_config.path),
+            "origin_fire_min_age": float(rule_config.fire_origin_min_age),
+            "origin_classification": "AGE_2020 threshold",
+            "logging_origin_stand_count": int(
+                support_rows["origin_class"].astype(str).eq("logging_origin").sum()
+            ),
+            "fire_origin_stand_count": int(
+                support_rows["origin_class"].astype(str).eq("fire_origin").sum()
+            ),
+            "logging_origin_si_count": int(len(logging_si)),
+            "all_stand_si_count": int(len(all_si)),
+            "managed_si_source": si_source,
+        }
+
+        if rule is None:
+            rows.append(
+                {
+                    **base_row,
+                    "bootstrap_status": "unmatched",
+                    "included_in_msyt": False,
+                    "mapping_path": "no_matching_managed_rule",
+                    "managed_si": managed_si,
+                    "managed_family_id": "",
+                    "density_total": np.nan,
+                    "regen_delay": np.nan,
+                    "oaf1": np.nan,
+                    "oaf2": np.nan,
+                    "planted_percent": np.nan,
+                    "baseline_system": "",
+                    "ct_eligible": False,
+                    "ct_target_age": np.nan,
+                    "ct_on_fire_origin": False,
+                    "hw_ingrowth_pct": 0.0,
+                    "hw_ingrowth_source": "unmatched",
+                    "managed_rule_notes": "",
+                    **_managed_species_payload_dict(
+                        ManagedSpeciesPayload("", "", "", "", "", 0, 0, 0, 0, 0),
+                        prefix="base_managed",
+                    ),
+                    "managed_species_overflow_to_hw_pct": 0.0,
+                    "managed_species_overflow_to_hw_codes": "",
+                    **_managed_species_payload_dict(
+                        ManagedSpeciesPayload("", "", "", "", "", 0, 0, 0, 0, 0)
+                    ),
+                }
+            )
+            continue
+
+        hw_ingrowth_pct, hw_ingrowth_source = resolve_hw_ingrowth_pct(
+            rule_config=rule_config,
+            au_id=au_id,
+        )
+        adjusted_species_mix = apply_hw_ingrowth_overlay(
+            species_mix=rule.species_mix,
+            hw_ingrowth_pct=hw_ingrowth_pct,
+        )
+        managed_payload, overflow_pct, overflow_codes = (
+            _managed_species_payload_from_mix_with_hw_overflow(adjusted_species_mix)
+        )
+        included = not pd.isna(managed_si)
+        rows.append(
+            {
+                **base_row,
+                "bootstrap_status": "expert_rule" if included else "unmatched",
+                "included_in_msyt": bool(included),
+                "mapping_path": (
+                    f"expert_rule_{si_source}"
+                    if included
+                    else f"expert_rule_{si_source}"
+                ),
+                "managed_si": managed_si,
+                "managed_family_id": rule.family_id,
+                "density_total": int(rule.density_total),
+                "regen_delay": int(rule.regen_delay),
+                "oaf1": float(rule.oaf1),
+                "oaf2": float(rule.oaf2),
+                "planted_percent": int(rule.planted_percent),
+                "baseline_system": rule.baseline_system,
+                "ct_eligible": bool(rule.ct_eligible),
+                "ct_target_age": int(rule.ct_target_age),
+                "ct_on_fire_origin": bool(rule.ct_on_fire_origin),
+                "hw_ingrowth_pct": float(hw_ingrowth_pct),
+                "hw_ingrowth_source": hw_ingrowth_source,
+                "managed_rule_notes": rule.notes,
+                **_managed_species_payload_dict(
+                    _managed_species_payload_from_mix(rule.species_mix),
+                    prefix="base_managed",
+                ),
+                "managed_species_overflow_to_hw_pct": overflow_pct,
+                "managed_species_overflow_to_hw_codes": overflow_codes,
+                **_managed_species_payload_dict(managed_payload),
+            }
+        )
+
+    return pd.DataFrame(rows)
+
+
+def build_mkrf_managed_au_msyt_table(
+    *,
+    bootstrap_table: pd.DataFrame,
+) -> pd.DataFrame:
+    included = bootstrap_table.loc[
+        bootstrap_table["included_in_msyt"].fillna(False)
+    ].copy()
+    if included.empty:
+        raise RuntimeError(
+            "No managed AU bootstrap rows available for MSYT generation."
+        )
+    included = included.sort_values(["selected_rank", "au_id"], kind="stable")
+    tipsy_rows: list[dict[str, Any]] = []
+    for _, row in included.iterrows():
+        tipsy_row: dict[str, Any] = {
+            "AU": int(row["managed_curve_id"]),
+            "BEC": _format_mkrf_bec(
+                str(row["bec_zone"]),
+                str(row["bec_subzone"]),
+                str(row["bec_variant"]),
+            ),
+            "Proportion": 1.0,
+            "Regen_Delay": int(row["regen_delay"]),
+            "Density": int(row["density_total"]),
+            "OAF1": float(row["oaf1"]),
+            "OAF2": float(row["oaf2"]),
+            "SI": float(row["managed_si"]),
+        }
+        for i in range(1, 6):
+            tipsy_row[f"SPP_{i}"] = row.get(f"managed_species_{i}", "")
+            tipsy_row[f"PCT_{i}"] = row.get(f"managed_pct_{i}", "")
+            tipsy_row[f"GW_{i}"] = ""
+        tipsy_rows.append(tipsy_row)
+    tipsy_table = pd.DataFrame(tipsy_rows)
+    return build_btc_msyt_input_table(tipsy_table=tipsy_table, pd_module=pd)
+
+
+def parse_mkrf_managed_au_curves(
+    *,
+    output_csv: Path,
+    bootstrap_table: pd.DataFrame,
+) -> pd.DataFrame:
+    parsed = parse_btc_tsr_transposed_output(output_csv=output_csv, pd_module=pd)
+    lookup = (
+        bootstrap_table.loc[
+            bootstrap_table["included_in_msyt"].fillna(False),
+            ["managed_curve_id", "au_id"],
+        ]
+        .copy()
+        .assign(
+            managed_curve_id=lambda df: pd.to_numeric(df["managed_curve_id"]).astype(
+                int
+            )
+        )
+    )
+    merged = parsed.merge(
+        lookup,
+        left_on="AU",
+        right_on="managed_curve_id",
+        how="left",
+        validate="many_to_one",
+    )
+    curves = merged.rename(
+        columns={
+            "Age": "age",
+            "Yield": "volume",
+            "Height": "height",
+            "DBHq": "dbhq",
+            "TPH": "tph",
+            "GrossYield": "gross_yield",
+            "CrownCover": "crown_cover",
+        }
+    )
+    ordered_columns = [
+        "au_id",
+        "managed_curve_id",
+        "age",
+        "volume",
+        "height",
+        "dbhq",
+        "tph",
+        "gross_yield",
+        "crown_cover",
+    ]
+    for column in ordered_columns:
+        if column not in curves.columns:
+            curves[column] = np.nan
+    return (
+        curves[ordered_columns]
+        .sort_values(
+            ["managed_curve_id", "age"],
+            kind="stable",
+        )
+        .reset_index(drop=True)
+    )
+
+
+def write_mkrf_managed_run_manifest(
+    *,
+    manifest_path: Path,
+    payload: Mapping[str, Any],
+) -> Path:
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return manifest_path
+
+
+def _match_managed_rule(
+    *,
+    rule_config: MkrfManagedRuleConfig,
+    bec_zone: str,
+    bec_subzone: str,
+    bec_variant: str,
+) -> MkrfManagedRule | None:
+    normalized = (
+        str(bec_zone).strip().lower(),
+        str(bec_subzone).strip().lower(),
+        str(bec_variant).strip().lower(),
+    )
+    for rule in rule_config.rules:
+        if (rule.bec_zone, rule.bec_subzone, rule.bec_variant) == normalized:
+            return rule
+    return None
+
+
+def resolve_hw_ingrowth_pct(
+    *,
+    rule_config: MkrfManagedRuleConfig,
+    au_id: str,
+    stand_id: str | int | None = None,
+) -> tuple[float, str]:
+    overlay = rule_config.hw_ingrowth_overlay
+    if not overlay.enabled:
+        return 0.0, "disabled"
+
+    if stand_id is not None and str(stand_id).strip():
+        stand_key = str(stand_id).strip()
+        if stand_key in overlay.stand_overrides_pct:
+            return float(overlay.stand_overrides_pct[stand_key]), "stand_override"
+
+    au_key = str(au_id).strip().lower()
+    if au_key in overlay.au_overrides_pct:
+        return float(overlay.au_overrides_pct[au_key]), "au_override"
+
+    return float(overlay.landscape_default_pct), "landscape_default"
+
+
+def apply_hw_ingrowth_overlay(
+    *,
+    species_mix: Mapping[str, float],
+    hw_ingrowth_pct: float,
+) -> dict[str, float]:
+    pct = _validate_percent(
+        hw_ingrowth_pct,
+        context="hw_ingrowth_pct",
+    )
+    fraction = pct / 100.0
+    adjusted: dict[str, float] = {}
+    hw_ingrowth_share = 0.0
+    for species, share_value in species_mix.items():
+        code = str(species).strip().upper()
+        share = float(share_value)
+        if code == "HW":
+            adjusted[code] = adjusted.get(code, 0.0) + share
+            continue
+        retained_share = share * (1.0 - fraction)
+        if retained_share > 0.0:
+            adjusted[code] = adjusted.get(code, 0.0) + retained_share
+        hw_ingrowth_share += share * fraction
+    if hw_ingrowth_share > 0.0:
+        adjusted["HW"] = adjusted.get("HW", 0.0) + hw_ingrowth_share
+    return adjusted
+
+
+def _managed_species_payload_dict(
+    payload: ManagedSpeciesPayload,
+    *,
+    prefix: str = "managed",
+) -> dict[str, Any]:
+    return {
+        f"{prefix}_species_1": payload.species_1,
+        f"{prefix}_species_2": payload.species_2,
+        f"{prefix}_species_3": payload.species_3,
+        f"{prefix}_species_4": payload.species_4,
+        f"{prefix}_species_5": payload.species_5,
+        f"{prefix}_pct_1": payload.pct_1,
+        f"{prefix}_pct_2": payload.pct_2,
+        f"{prefix}_pct_3": payload.pct_3,
+        f"{prefix}_pct_4": payload.pct_4,
+        f"{prefix}_pct_5": payload.pct_5,
+    }
+
+
+def _managed_species_payload_from_mix(
+    species_mix: Mapping[str, float],
+) -> ManagedSpeciesPayload:
+    ranked = sorted(
+        (
+            (str(species).strip().upper(), float(share))
+            for species, share in species_mix.items()
+            if float(share) > 0.0
+        ),
+        key=lambda item: (-item[1], item[0]),
+    )[:5]
+    while len(ranked) < 5:
+        ranked.append(("", 0.0))
+    return ManagedSpeciesPayload(
+        species_1=ranked[0][0],
+        species_2=ranked[1][0],
+        species_3=ranked[2][0],
+        species_4=ranked[3][0],
+        species_5=ranked[4][0],
+        pct_1=ranked[0][1],
+        pct_2=ranked[1][1],
+        pct_3=ranked[2][1],
+        pct_4=ranked[3][1],
+        pct_5=ranked[4][1],
+    )
+
+
+def _managed_species_payload_from_mix_with_hw_overflow(
+    species_mix: Mapping[str, float],
+) -> tuple[ManagedSpeciesPayload, float, str]:
+    positive = {
+        str(species).strip().upper(): float(share)
+        for species, share in species_mix.items()
+        if float(share) > 0.0
+    }
+    if len(positive) <= 5 or "HW" not in positive:
+        return _managed_species_payload_from_mix(positive), 0.0, ""
+
+    non_hw_ranked = sorted(
+        ((species, share) for species, share in positive.items() if species != "HW"),
+        key=lambda item: (-item[1], item[0]),
+    )
+    kept = dict(non_hw_ranked[:4])
+    dropped = non_hw_ranked[4:]
+    overflow_pct = float(sum(share for _, share in dropped))
+    if overflow_pct > 0.0:
+        kept["HW"] = positive["HW"] + overflow_pct
+    else:
+        kept["HW"] = positive["HW"]
+    overflow_codes = ",".join(species for species, _ in dropped)
+    return _managed_species_payload_from_mix(kept), overflow_pct, overflow_codes
+
+
+def _load_hw_ingrowth_overlay_config(
+    raw_overlay: Mapping[str, Any],
+    *,
+    path: Path,
+) -> HwIngrowthOverlayConfig:
+    if not isinstance(raw_overlay, Mapping):
+        raise ValueError(f"hw_ingrowth_overlay must be a mapping in {path}")
+    enabled = bool(raw_overlay.get("enabled", False))
+    landscape_default_pct = _validate_percent(
+        raw_overlay.get("landscape_default_pct", 0.0),
+        context="hw_ingrowth_overlay.landscape_default_pct",
+    )
+    return HwIngrowthOverlayConfig(
+        enabled=enabled,
+        landscape_default_pct=landscape_default_pct,
+        au_overrides_pct=_parse_percent_mapping(
+            raw_overlay.get("au_overrides_pct", {}) or {},
+            context="hw_ingrowth_overlay.au_overrides_pct",
+            lowercase_keys=True,
+        ),
+        stand_overrides_pct=_parse_percent_mapping(
+            raw_overlay.get("stand_overrides_pct", {}) or {},
+            context="hw_ingrowth_overlay.stand_overrides_pct",
+            lowercase_keys=False,
+        ),
+    )
+
+
+def _parse_percent_mapping(
+    raw_mapping: Mapping[str, Any],
+    *,
+    context: str,
+    lowercase_keys: bool,
+) -> dict[str, float]:
+    if not isinstance(raw_mapping, Mapping):
+        raise ValueError(f"{context} must be a mapping")
+    parsed: dict[str, float] = {}
+    for raw_key, raw_value in raw_mapping.items():
+        key = str(raw_key).strip()
+        if not key:
+            raise ValueError(f"{context} contains an empty key")
+        if lowercase_keys:
+            key = key.lower()
+        parsed[key] = _validate_percent(raw_value, context=f"{context}.{key}")
+    return parsed
+
+
+def _validate_percent(value: Any, *, context: str) -> float:
+    pct = float(value)
+    if not np.isfinite(pct) or pct < 0.0 or pct > 100.0:
+        raise ValueError(f"{context} must be between 0 and 100, got {value!r}")
+    return pct
+
+
+def _tipsy_species_pair(row: pd.Series) -> tuple[str, str]:
+    ranked: list[tuple[str, float]] = []
+    for column in _MANAGED_TIPSY_SPECIES_COLUMNS:
+        raw = row.get(column)
+        try:
+            share = float(raw)
+        except (TypeError, ValueError):
+            share = 0.0
+        if not np.isfinite(share) or share <= 0.0:
+            continue
+        ranked.append((column.lower() if column != "FD" else "fdc", share))
+    ranked.sort(key=lambda item: (-item[1], item[0]))
+    if not ranked:
+        return ("x", "x")
+    if len(ranked) == 1:
+        return (ranked[0][0], "x")
+    return (ranked[0][0], ranked[1][0])
+
+
+def _format_mkrf_bec(zone: str, subzone: str, variant: str) -> str:
+    base = f"{zone.upper()}{subzone}"
+    if variant == "x":
+        return base
+    return f"{base}{variant}"

--- a/src/mkrf_femic/workflows/__init__.py
+++ b/src/mkrf_femic/workflows/__init__.py
@@ -1,0 +1,1 @@
+"""MKRF workflow helpers."""

--- a/src/mkrf_femic/workflows/mkrf.py
+++ b/src/mkrf_femic/workflows/mkrf.py
@@ -1,0 +1,4482 @@
+"""MKRF-specific rebuild workflows."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import os
+from pathlib import Path
+from textwrap import dedent
+import xml.etree.ElementTree as et
+
+import geopandas as gpd
+import numpy as np
+import pandas as pd
+
+from mkrf_femic.pipeline.mkrf_au import (
+    build_mkrf_au_aggregation_audit,
+    build_mkrf_au_tables,
+    build_mkrf_selected_au_table,
+)
+from mkrf_femic.pipeline.mkrf_first_growth import (
+    _MIN_FIRST_GROWTH_SOURCE_STANDS,
+    build_mkrf_first_growth_curves,
+    collapse_stand_assignments,
+    _resolve_eligible_first_growth_feature_ids,
+)
+from mkrf_femic.pipeline.mkrf_managed import (
+    build_mkrf_stand_origin_assignment,
+    build_mkrf_managed_au_bootstrap_table,
+    build_mkrf_managed_au_msyt_table,
+    load_mkrf_managed_rule_config,
+    parse_mkrf_managed_au_curves,
+    write_mkrf_managed_run_manifest,
+)
+from femic.pipeline.plots import (
+    StrataDistributionPlotMetadata,
+    build_strata_distribution_plot_config,
+    render_strata_distribution_plot,
+    resolve_strata_plot_ordering,
+    strata_plot_paths,
+)
+from femic.pipeline.tipsy import run_btc_cli
+from femic.fmg.patchworks import validate_forestmodel_xml_tree, write_forestmodel_xml
+
+
+@dataclass(frozen=True)
+class MkrfAuBuildResult:
+    """Result payload for MKRF AU-input bundle materialization."""
+
+    resultant_gdb: Path
+    output_dir: Path
+    au_table_path: Path
+    stand_assignment_path: Path
+    aggregation_audit_path: Path
+    source_row_count: int
+    au_count: int
+
+
+@dataclass(frozen=True)
+class MkrfFirstGrowthBuildResult:
+    """Result payload for MKRF AU-wise first-growth curve materialization."""
+
+    vdyp_yields_csv: Path
+    assignment_csv: Path
+    output_dir: Path
+    curves_path: Path
+    diagnostics_path: Path
+    au_count: int
+    assigned_stand_count: int
+    raw_unmatched_source_stand_count: int
+    residual_unmatched_source_stand_count: int
+    lexmatch_assigned_stand_count: int
+
+
+def _parse_mkrf_au_id(au_id: str) -> tuple[str, str, str, str, str] | None:
+    parts = str(au_id).split("_")
+    if len(parts) != 5:
+        return None
+    return (parts[0], parts[1], parts[2], parts[3], parts[4])
+
+
+def _normalize_species_bucket(species_code: str) -> str:
+    code = str(species_code).strip().upper()
+    if code in {"BA"}:
+        return "Ba"
+    if code in {"CW"}:
+        return "Cw"
+    if code in {"DR"}:
+        return "Dr"
+    if code in {"FD", "FDC"}:
+        return "Fd"
+    if code in {"HW"}:
+        return "Hw"
+    if code in {"YC"}:
+        return "Yc"
+    if code in {"AC", "ACT", "AT", "EP", "MB"}:
+        return "Dec"
+    if code:
+        return "Oth"
+    return ""
+
+
+_SPECIES_BUCKETS = ("Ba", "Cw", "Dec", "Dr", "Fd", "Hw", "Oth", "Yc")
+_MKRF_CT_BUCKET_ANCHORS = (35, 40, 45)
+_MKRF_CT_BUCKET_WIDTH = 5
+_MKRF_CT_BUCKET_PREFIX_WIDTH = 3
+_MKRF_CT_TARGET_BA_REMOVAL_FRACTION = 0.45
+_MKRF_CT_MIN_CW_FD_SHARE_PCT = 50.0
+
+
+def _build_lookup_expr(keys: list[str], values: list[str], *, key_expr: str) -> str:
+    return f"lookupTable({key_expr},'{','.join(keys)}','{','.join(values)}')"
+
+
+def _mkrf_ct_bucket_label(anchor_age: int) -> str:
+    return f"CT{int(anchor_age)}"
+
+
+def _mkrf_ct_bucket_prefix(anchor_age: int) -> str:
+    return f"thn{int(anchor_age):0{_MKRF_CT_BUCKET_PREFIX_WIDTH}d}_"
+
+
+def _mkrf_ct_bucket_specs() -> tuple[dict[str, int | str], ...]:
+    return tuple(
+        {
+            "anchor_age": int(anchor_age),
+            "label": _mkrf_ct_bucket_label(anchor_age),
+            "prefix": _mkrf_ct_bucket_prefix(anchor_age),
+            "min_age": int(anchor_age),
+            "max_age": int(anchor_age) + _MKRF_CT_BUCKET_WIDTH - 1,
+        }
+        for anchor_age in _MKRF_CT_BUCKET_ANCHORS
+    )
+
+
+def _ct_product_species_fraction_expr(
+    share_column: str,
+    origin_share_lookup_exprs: dict[str, str],
+) -> str:
+    target = str(_MKRF_CT_TARGET_BA_REMOVAL_FRACTION)
+    hw_share = origin_share_lookup_exprs["share_hw"]
+    fd_share = origin_share_lookup_exprs["share_fd"]
+    if share_column == "share_cw":
+        return "0"
+    if share_column == "share_hw":
+        return f"if(({hw_share}) gt {target},1,({hw_share})/{target})"
+    if share_column == "share_fd":
+        return (
+            f"if(({hw_share}) gt {target},0,"
+            f"if(({hw_share})+({fd_share}) gt {target},"
+            f"({target}-({hw_share}))/{target},({fd_share})/{target}))"
+        )
+    if share_column == "share_oth":
+        return (
+            f"if(({hw_share})+({fd_share}) gt {target},0,"
+            f"({target}-({hw_share})-({fd_share}))/{target})"
+        )
+    return "0"
+
+
+def _build_managed_species_share_table(
+    managed_bootstrap_table: pd.DataFrame,
+    *,
+    species_prefix: str = "managed",
+) -> pd.DataFrame:
+    rows: list[dict[str, object]] = []
+    for row in managed_bootstrap_table.itertuples(index=False):
+        shares = {bucket: 0.0 for bucket in _SPECIES_BUCKETS}
+        for index in range(1, 6):
+            species_code = getattr(row, f"{species_prefix}_species_{index}", "")
+            pct_value = pd.to_numeric(
+                getattr(row, f"{species_prefix}_pct_{index}", 0.0), errors="coerce"
+            )
+            if pd.isna(pct_value) or float(pct_value) <= 0:
+                continue
+            bucket = _normalize_species_bucket(str(species_code))
+            if bucket:
+                shares[bucket] += float(pct_value)
+        row_payload = {"au_id": str(row.au_id).strip()}
+        row_payload.update(
+            {f"share_{bucket.lower()}": shares[bucket] for bucket in shares}
+        )
+        rows.append(row_payload)
+    return pd.DataFrame(rows)
+
+
+def _build_unmanaged_species_share_table(
+    stand_assignment: pd.DataFrame,
+    *,
+    selected_au_table: pd.DataFrame | None = None,
+) -> pd.DataFrame:
+    rows = stand_assignment.copy()
+    rows["au_id"] = rows["au_id"].astype(str).str.strip()
+    if selected_au_table is not None:
+        selected_ids = set(selected_au_table["au_id"].astype(str).str.strip())
+        rows = rows.loc[rows["au_id"].isin(selected_ids)].copy()
+
+    rows["shape_area_ha"] = pd.to_numeric(
+        rows["shape_area_ha"], errors="coerce"
+    ).fillna(0.0)
+    rows["leading_species_1_share"] = pd.to_numeric(
+        rows["leading_species_1_share"], errors="coerce"
+    ).fillna(0.0)
+    rows["leading_species_2_share"] = pd.to_numeric(
+        rows["leading_species_2_share"], errors="coerce"
+    ).fillna(0.0)
+
+    payload_rows: list[dict[str, object]] = []
+    for row in rows.itertuples(index=False):
+        area_ha = float(row.shape_area_ha)
+        if area_ha <= 0:
+            continue
+
+        shares = {bucket: 0.0 for bucket in _SPECIES_BUCKETS}
+        species_1 = _normalize_species_bucket(getattr(row, "leading_species_1", ""))
+        species_2 = _normalize_species_bucket(getattr(row, "leading_species_2", ""))
+        species_1_share = max(float(row.leading_species_1_share), 0.0)
+        species_2_share = max(float(row.leading_species_2_share), 0.0)
+
+        if species_1:
+            shares[species_1] += area_ha * species_1_share / 100.0
+        if species_2:
+            shares[species_2] += area_ha * species_2_share / 100.0
+
+        residual_share = max(0.0, 100.0 - species_1_share - species_2_share)
+        shares["Oth"] += area_ha * residual_share / 100.0
+
+        payload = {
+            "au_id": str(row.au_id).strip(),
+            "area_ha": area_ha,
+        }
+        payload.update(
+            {
+                f"share_{bucket.lower()}_ha": shares[bucket]
+                for bucket in _SPECIES_BUCKETS
+            }
+        )
+        payload_rows.append(payload)
+
+    if not payload_rows:
+        return pd.DataFrame(
+            columns=[
+                "au_id",
+                "area_ha",
+                *[f"share_{bucket.lower()}" for bucket in _SPECIES_BUCKETS],
+            ]
+        )
+
+    aggregated = (
+        pd.DataFrame(payload_rows)
+        .groupby("au_id", as_index=False)
+        .sum(numeric_only=True)
+    )
+    for bucket in _SPECIES_BUCKETS:
+        area_column = f"share_{bucket.lower()}_ha"
+        share_column = f"share_{bucket.lower()}"
+        aggregated[share_column] = np.where(
+            aggregated["area_ha"].gt(0),
+            aggregated[area_column] / aggregated["area_ha"] * 100.0,
+            0.0,
+        )
+
+    return aggregated[
+        ["au_id", *[f"share_{bucket.lower()}" for bucket in _SPECIES_BUCKETS]]
+    ]
+
+
+def _build_species_share_audit_table(
+    *,
+    managed_species_shares: pd.DataFrame,
+    unmanaged_species_shares: pd.DataFrame,
+) -> pd.DataFrame:
+    rows: list[dict[str, object]] = []
+    for origin_lane, source_name, frame in (
+        ("treated", "managed_bootstrap", managed_species_shares),
+        ("natural", "stand_au_assignment", unmanaged_species_shares),
+    ):
+        if frame.empty:
+            continue
+        working = frame.copy()
+        working["au_id"] = working["au_id"].astype(str).str.strip()
+        for row in working.itertuples(index=False):
+            for bucket in _SPECIES_BUCKETS:
+                share_pct = float(
+                    pd.to_numeric(
+                        getattr(row, f"share_{bucket.lower()}", 0.0), errors="coerce"
+                    )
+                    or 0.0
+                )
+                rows.append(
+                    {
+                        "origin_lane": origin_lane,
+                        "source_name": source_name,
+                        "au_id": str(row.au_id).strip(),
+                        "species_bucket": bucket,
+                        "share_pct": share_pct,
+                        "share_class": "nonzero" if share_pct > 0 else "zero",
+                    }
+                )
+    return pd.DataFrame(rows).sort_values(
+        ["origin_lane", "source_name", "au_id", "species_bucket"],
+        kind="stable",
+    )
+
+
+def _build_ct_eligibility_audit_table(
+    *,
+    selected_au_table: pd.DataFrame,
+    ct_eligibility_species_shares: pd.DataFrame,
+) -> pd.DataFrame:
+    selected = selected_au_table.copy()
+    selected["au_id"] = selected["au_id"].astype(str).str.strip()
+    if (
+        "leading_species_1" not in selected.columns
+        or "leading_species_2" not in selected.columns
+    ):
+        parsed = selected["au_id"].map(_parse_mkrf_au_id)
+        selected["leading_species_1"] = [
+            parts[3] if parts is not None else "" for parts in parsed
+        ]
+        selected["leading_species_2"] = [
+            parts[4] if parts is not None else "" for parts in parsed
+        ]
+    selected = selected.drop_duplicates(subset=["au_id"], keep="first")
+    shares = ct_eligibility_species_shares.copy()
+    shares["au_id"] = shares["au_id"].astype(str).str.strip()
+    audit = selected[["au_id", "leading_species_1", "leading_species_2"]].merge(
+        shares[
+            [
+                "au_id",
+                "share_cw",
+                "share_fd",
+                "share_hw",
+                "share_cw_fd",
+            ]
+        ],
+        on="au_id",
+        how="left",
+        validate="one_to_one",
+    )
+    for column in ("share_cw", "share_fd", "share_hw", "share_cw_fd"):
+        audit[column] = pd.to_numeric(audit[column], errors="coerce").fillna(0.0)
+    leading_species = (
+        audit["leading_species_1"].astype(str).str.lower()
+        + "_"
+        + audit["leading_species_2"].astype(str).str.lower()
+    )
+    audit["runtime_operable_or_ground_candidate"] = ~leading_species.str.contains(
+        r"(?:^|_)ba(?:$|_)", regex=True
+    )
+    audit["runtime_ct_eligible_before_species_filter"] = audit[
+        "runtime_operable_or_ground_candidate"
+    ]
+    audit["cw_fd_threshold_pct"] = float(_MKRF_CT_MIN_CW_FD_SHARE_PCT)
+    audit["cw_fd_ge_threshold"] = audit["share_cw_fd"].ge(_MKRF_CT_MIN_CW_FD_SHARE_PCT)
+    audit["final_ct_eligible"] = (
+        audit["runtime_ct_eligible_before_species_filter"] & audit["cw_fd_ge_threshold"]
+    )
+
+    def _reasons(row: pd.Series) -> str:
+        reasons: list[str] = []
+        if not bool(row["runtime_ct_eligible_before_species_filter"]):
+            reasons.append("runtime_ct_or_operability_seam")
+        if not bool(row["cw_fd_ge_threshold"]):
+            reasons.append("cw_fd_share_lt_50")
+        return ";".join(reasons)
+
+    audit["exclusion_reasons"] = audit.apply(_reasons, axis=1)
+    audit = audit.rename(
+        columns={
+            "share_cw": "base_cw_share_pct",
+            "share_fd": "base_fd_share_pct",
+            "share_hw": "base_hw_share_pct",
+            "share_cw_fd": "base_cw_fd_share_pct",
+        }
+    )
+    return audit[
+        [
+            "au_id",
+            "runtime_operable_or_ground_candidate",
+            "runtime_ct_eligible_before_species_filter",
+            "base_cw_share_pct",
+            "base_fd_share_pct",
+            "base_hw_share_pct",
+            "base_cw_fd_share_pct",
+            "cw_fd_threshold_pct",
+            "cw_fd_ge_threshold",
+            "final_ct_eligible",
+            "exclusion_reasons",
+        ]
+    ].sort_values("au_id", kind="stable")
+
+
+def _ct_product_fraction_values(
+    *, hw_share: float, fd_share: float
+) -> dict[str, float]:
+    target = float(_MKRF_CT_TARGET_BA_REMOVAL_FRACTION)
+    hw_fraction = 1.0 if hw_share > target else hw_share / target
+    if hw_share > target:
+        fd_fraction = 0.0
+    elif hw_share + fd_share > target:
+        fd_fraction = (target - hw_share) / target
+    else:
+        fd_fraction = fd_share / target
+    other_fraction = (
+        0.0 if hw_share + fd_share > target else (target - hw_share - fd_share) / target
+    )
+    return {
+        "cw": 0.0,
+        "hw": max(0.0, hw_fraction),
+        "fd": max(0.0, fd_fraction),
+        "other": max(0.0, other_fraction),
+    }
+
+
+def _build_ct_intensity_audit_tables(
+    *,
+    ct_eligibility_audit: pd.DataFrame,
+    treated_species_shares: pd.DataFrame,
+    ct_bucket_specs: tuple[dict[str, int | str], ...],
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    eligible = ct_eligibility_audit.loc[
+        ct_eligibility_audit["final_ct_eligible"].fillna(False).astype(bool)
+    ].copy()
+    treated = treated_species_shares.copy()
+    treated["au_id"] = treated["au_id"].astype(str).str.strip()
+    rows: list[dict[str, object]] = []
+    for eligible_row in eligible.itertuples(index=False):
+        share_row = treated.loc[treated["au_id"].eq(str(eligible_row.au_id))]
+        if share_row.empty:
+            continue
+        share = share_row.iloc[0]
+        treated_cw = float(
+            pd.to_numeric(share.get("share_cw", 0.0), errors="coerce") or 0.0
+        )
+        treated_hw = float(
+            pd.to_numeric(share.get("share_hw", 0.0), errors="coerce") or 0.0
+        )
+        treated_fd = float(
+            pd.to_numeric(share.get("share_fd", 0.0), errors="coerce") or 0.0
+        )
+        treated_other = max(0.0, 100.0 - treated_cw - treated_hw - treated_fd)
+        fractions = _ct_product_fraction_values(
+            hw_share=treated_hw / 100.0,
+            fd_share=treated_fd / 100.0,
+        )
+        for bucket_spec in ct_bucket_specs:
+            rows.append(
+                {
+                    "au_id": str(eligible_row.au_id),
+                    "treatment": str(bucket_spec["label"]),
+                    "ct_target_removal_fraction": float(
+                        _MKRF_CT_TARGET_BA_REMOVAL_FRACTION
+                    ),
+                    "base_cw_fd_share_pct": float(eligible_row.base_cw_fd_share_pct),
+                    "treated_cw_share_pct": treated_cw,
+                    "treated_hw_share_pct": treated_hw,
+                    "treated_fd_share_pct": treated_fd,
+                    "previous_composition_proportional_cw_product_fraction": treated_cw
+                    / 100.0,
+                    "previous_composition_proportional_hw_product_fraction": treated_hw
+                    / 100.0,
+                    "previous_composition_proportional_fd_product_fraction": treated_fd
+                    / 100.0,
+                    "previous_composition_proportional_other_product_fraction": treated_other
+                    / 100.0,
+                    "implemented_ct_cw_product_fraction": fractions["cw"],
+                    "implemented_ct_hw_product_fraction": fractions["hw"],
+                    "implemented_ct_fd_product_fraction": fractions["fd"],
+                    "implemented_ct_other_product_fraction": fractions["other"],
+                    "implemented_ct_product_fraction_sum": sum(fractions.values()),
+                    "prescription_note": "target_bounded_hw_first_fd_balancer_cw_retained_fd_secondary",
+                }
+            )
+    audit = pd.DataFrame(rows)
+    if audit.empty:
+        summary = pd.DataFrame(
+            columns=[
+                "treatment",
+                "au_count",
+                "max_implemented_cw_product_fraction",
+                "min_implemented_hw_product_fraction",
+                "max_implemented_hw_product_fraction",
+                "max_implemented_fd_product_fraction",
+            ]
+        )
+        return audit, summary
+    summary = (
+        audit.groupby("treatment", as_index=False)
+        .agg(
+            au_count=("au_id", "nunique"),
+            max_implemented_cw_product_fraction=(
+                "implemented_ct_cw_product_fraction",
+                "max",
+            ),
+            min_implemented_hw_product_fraction=(
+                "implemented_ct_hw_product_fraction",
+                "min",
+            ),
+            max_implemented_hw_product_fraction=(
+                "implemented_ct_hw_product_fraction",
+                "max",
+            ),
+            max_implemented_fd_product_fraction=(
+                "implemented_ct_fd_product_fraction",
+                "max",
+            ),
+        )
+        .sort_values("treatment", kind="stable")
+    )
+    return audit.sort_values(["au_id", "treatment"], kind="stable"), summary
+
+
+def _build_hw_ingrowth_overlay_audit_tables(
+    *,
+    managed_bootstrap: pd.DataFrame,
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    species_codes = ("BA", "CW", "DR", "FD", "HW", "PW", "SS", "YC")
+    rows: list[dict[str, object]] = []
+    if "included_in_msyt" in managed_bootstrap.columns:
+        included = managed_bootstrap.loc[
+            managed_bootstrap["included_in_msyt"].fillna(False).astype(bool)
+        ].copy()
+    else:
+        included = managed_bootstrap.copy()
+    for bootstrap_row in included.itertuples(index=False):
+        density_total = float(
+            pd.to_numeric(getattr(bootstrap_row, "density_total", 0.0), errors="coerce")
+            or 0.0
+        )
+        payload: dict[str, object] = {
+            "au_id": str(getattr(bootstrap_row, "au_id")),
+            "managed_family_id": str(getattr(bootstrap_row, "managed_family_id", "")),
+            "density_total": density_total,
+            "hw_ingrowth_pct": float(
+                pd.to_numeric(
+                    getattr(bootstrap_row, "hw_ingrowth_pct", 0.0),
+                    errors="coerce",
+                )
+                or 0.0
+            ),
+            "hw_ingrowth_source": str(getattr(bootstrap_row, "hw_ingrowth_source", "")),
+            "managed_species_overflow_to_hw_pct": float(
+                pd.to_numeric(
+                    getattr(bootstrap_row, "managed_species_overflow_to_hw_pct", 0.0),
+                    errors="coerce",
+                )
+                or 0.0
+            ),
+            "managed_species_overflow_to_hw_codes": str(
+                getattr(bootstrap_row, "managed_species_overflow_to_hw_codes", "")
+            ),
+        }
+        for species_code in species_codes:
+            code = species_code.lower()
+            base_pct = 0.0
+            adjusted_pct = 0.0
+            for index in range(1, 6):
+                base_species = str(
+                    getattr(bootstrap_row, f"base_managed_species_{index}", "")
+                ).upper()
+                adjusted_species = str(
+                    getattr(bootstrap_row, f"managed_species_{index}", "")
+                ).upper()
+                base_value = pd.to_numeric(
+                    getattr(bootstrap_row, f"base_managed_pct_{index}", 0.0),
+                    errors="coerce",
+                )
+                adjusted_value = pd.to_numeric(
+                    getattr(bootstrap_row, f"managed_pct_{index}", 0.0),
+                    errors="coerce",
+                )
+                if base_species == species_code and not pd.isna(base_value):
+                    base_pct += float(base_value)
+                if adjusted_species == species_code and not pd.isna(adjusted_value):
+                    adjusted_pct += float(adjusted_value)
+            payload[f"base_{code}_pct"] = base_pct
+            payload[f"adjusted_{code}_pct"] = adjusted_pct
+            payload[f"delta_{code}_pct"] = adjusted_pct - base_pct
+            payload[f"base_{code}_sph"] = density_total * base_pct / 100.0
+            payload[f"adjusted_{code}_sph"] = density_total * adjusted_pct / 100.0
+            payload[f"delta_{code}_sph"] = (
+                density_total * (adjusted_pct - base_pct) / 100.0
+            )
+        payload["base_pct_total"] = sum(
+            float(payload[f"base_{species_code.lower()}_pct"])
+            for species_code in species_codes
+        )
+        payload["adjusted_pct_total"] = sum(
+            float(payload[f"adjusted_{species_code.lower()}_pct"])
+            for species_code in species_codes
+        )
+        payload["base_sph_total"] = (
+            density_total * float(payload["base_pct_total"]) / 100.0
+        )
+        payload["adjusted_sph_total"] = (
+            density_total * float(payload["adjusted_pct_total"]) / 100.0
+        )
+        rows.append(payload)
+    audit = pd.DataFrame(rows).sort_values("au_id", kind="stable")
+    if audit.empty:
+        return audit, pd.DataFrame(
+            columns=[
+                "managed_family_id",
+                "au_count",
+                "mean_hw_ingrowth_pct",
+                "mean_base_hw_sph",
+                "mean_adjusted_hw_sph",
+                "mean_delta_hw_sph",
+                "overflow_au_count",
+            ]
+        )
+    summary = (
+        audit.groupby("managed_family_id", as_index=False)
+        .agg(
+            au_count=("au_id", "nunique"),
+            mean_hw_ingrowth_pct=("hw_ingrowth_pct", "mean"),
+            mean_base_hw_sph=("base_hw_sph", "mean"),
+            mean_adjusted_hw_sph=("adjusted_hw_sph", "mean"),
+            mean_delta_hw_sph=("delta_hw_sph", "mean"),
+            overflow_au_count=(
+                "managed_species_overflow_to_hw_pct",
+                lambda values: int(
+                    (pd.to_numeric(values, errors="coerce").fillna(0.0) > 0).sum()
+                ),
+            ),
+        )
+        .sort_values("managed_family_id", kind="stable")
+    )
+    return audit, summary
+
+
+def _normalize_runtime_au_assignments(
+    *,
+    selected_au_table: pd.DataFrame,
+    stand_origin_assignment: pd.DataFrame,
+    managed_curves: pd.DataFrame,
+    first_growth_diagnostics: pd.DataFrame,
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Normalize raw stand-origin AU assignments onto the canonical selected AU set."""
+    selected = selected_au_table.copy()
+    selected["au_id"] = selected["au_id"].astype(str).str.strip()
+    selected_parts = selected["au_id"].map(_parse_mkrf_au_id)
+    selected = selected.loc[selected_parts.notna()].copy()
+    selected[
+        [
+            "bec_zone",
+            "bec_subzone",
+            "bec_variant",
+            "leading_species_1",
+            "leading_species_2",
+        ]
+    ] = pd.DataFrame(selected_parts.loc[selected.index].tolist(), index=selected.index)
+    if "selected_rank" in selected.columns:
+        selected["selected_rank"] = pd.to_numeric(
+            selected["selected_rank"], errors="coerce"
+        ).fillna(10**9)
+    else:
+        selected["selected_rank"] = float(10**9)
+
+    managed_ids = set(managed_curves["au_id"].astype(str).str.strip().unique())
+    fg_paths = (
+        first_growth_diagnostics[["au_id", "selected_path"]]
+        .drop_duplicates(subset=["au_id"], keep="last")
+        .assign(
+            au_id=lambda df: df["au_id"].astype(str).str.strip(),
+            selected_path=lambda df: df["selected_path"].astype(str).str.strip(),
+        )
+    )
+    selected = selected.merge(fg_paths, on="au_id", how="left")
+    selected["has_managed_curve"] = selected["au_id"].isin(managed_ids)
+    selected["has_first_growth_curve"] = selected["selected_path"].notna() & (
+        ~selected["selected_path"].eq("insufficient_source_stands")
+    )
+    selected["runtime_coverage_rank"] = np.where(
+        selected["has_first_growth_curve"] & selected["has_managed_curve"],
+        2,
+        np.where(selected["has_managed_curve"], 1, 0),
+    )
+
+    selected_by_bec: dict[tuple[str, str, str], list[dict[str, object]]] = {}
+    for row in selected.itertuples(index=False):
+        key = (str(row.bec_zone), str(row.bec_subzone), str(row.bec_variant))
+        selected_by_bec.setdefault(key, []).append(
+            {
+                "au_id": str(row.au_id),
+                "leading_species_1": str(row.leading_species_1),
+                "leading_species_2": str(row.leading_species_2),
+                "runtime_coverage_rank": int(row.runtime_coverage_rank),
+                "selected_rank": float(row.selected_rank),
+            }
+        )
+
+    def choose_canonical_au(raw_au_id: str) -> tuple[str, str]:
+        parsed = _parse_mkrf_au_id(raw_au_id)
+        if parsed is None:
+            return raw_au_id, "unparsed_raw_au_id"
+        bec_zone, bec_subzone, bec_variant, raw_sp1, raw_sp2 = parsed
+        candidates = selected_by_bec.get((bec_zone, bec_subzone, bec_variant), [])
+        if not candidates:
+            return raw_au_id, "no_selected_au_same_bec"
+
+        def score(
+            candidate: dict[str, object],
+        ) -> tuple[int, int, int, int, float, str]:
+            cand_sp1 = str(candidate["leading_species_1"])
+            cand_sp2 = str(candidate["leading_species_2"])
+            overlap = len({raw_sp1, raw_sp2} & {cand_sp1, cand_sp2})
+            return (
+                int(cand_sp1 == raw_sp1),
+                int(candidate["runtime_coverage_rank"]),
+                int(cand_sp2 == raw_sp2),
+                overlap,
+                -float(candidate["selected_rank"]),
+                str(candidate["au_id"]),
+            )
+
+        best = max(candidates, key=score)
+        return str(best["au_id"]), "same_bec_species_coverage_rank"
+
+    normalized = (
+        stand_origin_assignment.copy()
+        .assign(
+            forest_cover_id=lambda df: pd.to_numeric(
+                df["forest_cover_id"], errors="coerce"
+            ),
+            raw_au_id=lambda df: df["au_id"].astype(str).str.strip(),
+        )
+        .dropna(subset=["forest_cover_id"])
+        .loc[lambda df: df["raw_au_id"].ne("")]
+    )
+    normalized["au_id"] = normalized["raw_au_id"]
+    normalized["remap_reason"] = "already_selected"
+    selected_ids = set(selected["au_id"])
+    remap_mask = ~normalized["raw_au_id"].isin(selected_ids)
+    remap_targets = normalized.loc[remap_mask, "raw_au_id"].map(choose_canonical_au)
+    normalized.loc[remap_mask, "au_id"] = remap_targets.map(lambda item: item[0])
+    normalized.loc[remap_mask, "remap_reason"] = remap_targets.map(lambda item: item[1])
+    normalized["was_remapped"] = normalized["raw_au_id"] != normalized["au_id"]
+
+    remap_audit = (
+        normalized.groupby(
+            ["raw_au_id", "au_id", "was_remapped", "remap_reason"],
+            dropna=False,
+            as_index=False,
+        )
+        .agg(
+            forest_cover_id_count=("forest_cover_id", "nunique"),
+            assignment_row_count=("forest_cover_id", "size"),
+        )
+        .sort_values(
+            ["was_remapped", "forest_cover_id_count", "raw_au_id"],
+            ascending=[False, False, True],
+            kind="stable",
+        )
+        .reset_index(drop=True)
+    )
+    return normalized, remap_audit
+
+
+def _apply_young_skewed_sibling_borrow(
+    *,
+    curves: pd.DataFrame,
+    diagnostics: pd.DataFrame,
+    assignment: pd.DataFrame,
+    source_table: pd.DataFrame,
+    min_first_growth_age: float = 80.0,
+    max_old_support_count: int = 1,
+    low_terminal_threshold: float = 100.0,
+    sibling_terminal_threshold: float = 100.0,
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Borrow a sane sibling curve for clearly too-young low-terminal cases."""
+    if curves.empty or diagnostics.empty:
+        return curves, diagnostics
+
+    stand_assignment = collapse_stand_assignments(assignment)
+    source_subset = source_table.copy()
+    source_subset["forest_cover_id"] = pd.to_numeric(
+        source_subset["FOREST_COVER_ID"], errors="coerce"
+    )
+    source_subset["AGE_2020"] = pd.to_numeric(
+        source_subset["AGE_2020"], errors="coerce"
+    )
+    age_rows = stand_assignment.merge(
+        source_subset[["forest_cover_id", "AGE_2020"]],
+        on="forest_cover_id",
+        how="left",
+    )
+    old_support = (
+        age_rows.groupby("au_id", as_index=False)["AGE_2020"]
+        .apply(
+            lambda s: int(
+                (pd.to_numeric(s, errors="coerce") >= min_first_growth_age).sum()
+            )
+        )
+        .rename(columns={"AGE_2020": "age_gte_80_count"})
+    )
+
+    terminal_curves = (
+        curves.sort_values(["au_id", "age"], kind="stable")
+        .groupby("au_id", as_index=False)
+        .tail(1)[["au_id", "volume"]]
+        .rename(columns={"volume": "terminal_volume"})
+    )
+
+    diagnostics_out = diagnostics.copy()
+    for column in ["borrowed_from_au_id", "borrow_reason"]:
+        if column not in diagnostics_out.columns:
+            diagnostics_out[column] = ""
+
+    summary = diagnostics_out.merge(old_support, on="au_id", how="left").merge(
+        terminal_curves, on="au_id", how="left"
+    )
+    summary["age_gte_80_count"] = (
+        pd.to_numeric(summary["age_gte_80_count"], errors="coerce")
+        .fillna(0)
+        .astype(int)
+    )
+    summary["terminal_volume"] = pd.to_numeric(
+        summary["terminal_volume"], errors="coerce"
+    )
+
+    curves_out = curves.copy()
+    terminal_lookup = {
+        str(row["au_id"]): float(row["terminal_volume"])
+        for _, row in summary.dropna(subset=["terminal_volume"]).iterrows()
+    }
+
+    for _, row in summary.iterrows():
+        au_id = str(row["au_id"])
+        terminal_volume = pd.to_numeric(row["terminal_volume"], errors="coerce")
+        if pd.isna(terminal_volume):
+            continue
+        if int(row["age_gte_80_count"]) > max_old_support_count:
+            continue
+        if float(terminal_volume) >= low_terminal_threshold:
+            continue
+
+        parsed = _parse_mkrf_au_id(au_id)
+        if parsed is None:
+            continue
+        bec_zone, bec_subzone, bec_variant, sp1, sp2 = parsed
+        sibling_au_id = f"{bec_zone}_{bec_subzone}_{bec_variant}_{sp2}_{sp1}"
+        sibling_terminal = terminal_lookup.get(sibling_au_id)
+        if sibling_terminal is None or sibling_terminal < sibling_terminal_threshold:
+            continue
+
+        sibling_curve = curves_out.loc[curves_out["au_id"] == sibling_au_id].copy()
+        if sibling_curve.empty:
+            continue
+        curves_out = curves_out.loc[curves_out["au_id"] != au_id].copy()
+        sibling_curve["au_id"] = au_id
+        curves_out = pd.concat(
+            [curves_out, sibling_curve], ignore_index=True, sort=False
+        )
+        diagnostics_out.loc[diagnostics_out["au_id"] == au_id, "selected_path"] = (
+            "borrowed_young_skewed_sibling"
+        )
+        diagnostics_out.loc[
+            diagnostics_out["au_id"] == au_id, "borrowed_from_au_id"
+        ] = sibling_au_id
+        diagnostics_out.loc[diagnostics_out["au_id"] == au_id, "borrow_reason"] = (
+            f"old_support<={max_old_support_count}_and_terminal<{low_terminal_threshold:g}"
+        )
+
+    curves_out = curves_out.sort_values(["au_id", "age"], kind="stable").reset_index(
+        drop=True
+    )
+    diagnostics_out = diagnostics_out.sort_values("au_id", kind="stable").reset_index(
+        drop=True
+    )
+    return curves_out, diagnostics_out
+
+
+def _apply_insufficient_support_merge(
+    *,
+    curves: pd.DataFrame,
+    diagnostics: pd.DataFrame,
+    assignment: pd.DataFrame,
+    source_table: pd.DataFrame,
+    min_first_growth_age: float = 80.0,
+    min_source_stands: int = _MIN_FIRST_GROWTH_SOURCE_STANDS,
+    min_donor_terminal_volume: float = 100.0,
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Borrow a larger accepted curve from the same BEC bucket for sparse units.
+
+    Old-support stand counts intentionally use fragment-level assignment rows so
+    this helper stays aligned with the bad-curve audit surface.
+    """
+    if diagnostics.empty and curves.empty:
+        return curves, diagnostics
+
+    area_by_au = (
+        assignment.groupby("au_id", as_index=False)["shape_area_ha"]
+        .sum()
+        .rename(columns={"shape_area_ha": "covered_area_ha"})
+    )
+    assignment_rows = assignment.copy()
+    assignment_rows["forest_cover_id"] = pd.to_numeric(
+        assignment_rows["forest_cover_id"], errors="coerce"
+    )
+    source_subset = source_table.copy()
+    source_subset["forest_cover_id"] = pd.to_numeric(
+        source_subset["FOREST_COVER_ID"], errors="coerce"
+    )
+    source_subset["AGE_2020"] = pd.to_numeric(
+        source_subset["AGE_2020"], errors="coerce"
+    )
+    age_rows = assignment_rows.merge(
+        source_subset[["forest_cover_id", "AGE_2020"]],
+        on="forest_cover_id",
+        how="left",
+    )
+    old_support = (
+        age_rows.loc[age_rows["AGE_2020"] >= min_first_growth_age]
+        .groupby("au_id", as_index=False)["forest_cover_id"]
+        .nunique()
+        .rename(columns={"forest_cover_id": "old_support_stand_count"})
+    )
+    terminal_curves = (
+        curves.sort_values(["au_id", "age"], kind="stable")
+        .groupby("au_id", as_index=False)
+        .tail(1)[["au_id", "volume"]]
+        .rename(columns={"volume": "terminal_volume"})
+    )
+
+    diagnostics_out = diagnostics.copy()
+    for column in ["borrowed_from_au_id", "borrow_reason"]:
+        if column not in diagnostics_out.columns:
+            diagnostics_out[column] = ""
+
+    base_summary = (
+        pd.DataFrame({"au_id": sorted(assignment["au_id"].astype(str).unique())})
+        .merge(diagnostics_out, on="au_id", how="left")
+        .merge(old_support, on="au_id", how="left")
+    )
+    summary = base_summary.merge(area_by_au, on="au_id", how="left").merge(
+        terminal_curves, on="au_id", how="left"
+    )
+    summary["covered_area_ha"] = pd.to_numeric(
+        summary["covered_area_ha"], errors="coerce"
+    ).fillna(0.0)
+    summary["terminal_volume"] = pd.to_numeric(
+        summary["terminal_volume"], errors="coerce"
+    )
+    summary["old_support_stand_count"] = (
+        pd.to_numeric(summary["old_support_stand_count"], errors="coerce")
+        .fillna(0)
+        .astype(int)
+    )
+    summary["accepted"] = summary["accepted"].fillna(False)
+
+    curves_out = curves.copy()
+    for _, row in summary.sort_values(
+        ["covered_area_ha", "au_id"], ascending=[False, True]
+    ).iterrows():
+        target_au_id = str(row["au_id"])
+        target_selected_path = str(row.get("selected_path", ""))
+        has_missing_curve = pd.isna(row.get("terminal_volume"))
+        insufficient_support = (
+            0 < int(row["old_support_stand_count"]) < int(min_source_stands)
+        )
+        if not (
+            target_selected_path == "insufficient_source_stands"
+            or (has_missing_curve and insufficient_support)
+        ):
+            continue
+
+        parsed_target = _parse_mkrf_au_id(target_au_id)
+        if parsed_target is None:
+            continue
+        target_zone, target_subzone, target_variant, target_sp1, target_sp2 = (
+            parsed_target
+        )
+
+        candidates: list[tuple[int, float, str]] = []
+        for _, candidate in summary.iterrows():
+            candidate_au_id = str(candidate["au_id"])
+            if candidate_au_id == target_au_id:
+                continue
+            if not bool(candidate.get("accepted", False)):
+                continue
+            candidate_terminal = pd.to_numeric(
+                candidate.get("terminal_volume"), errors="coerce"
+            )
+            if (
+                pd.isna(candidate_terminal)
+                or float(candidate_terminal) <= 0.0
+                or float(candidate_terminal) < float(min_donor_terminal_volume)
+            ):
+                continue
+            parsed_candidate = _parse_mkrf_au_id(candidate_au_id)
+            if parsed_candidate is None:
+                continue
+            cand_zone, cand_subzone, cand_variant, cand_sp1, cand_sp2 = parsed_candidate
+            if (cand_zone, cand_subzone, cand_variant) != (
+                target_zone,
+                target_subzone,
+                target_variant,
+            ):
+                continue
+            shared_species = len({target_sp1, target_sp2} & {cand_sp1, cand_sp2})
+            candidate_area = float(
+                pd.to_numeric(candidate["covered_area_ha"], errors="coerce")
+            )
+            candidates.append((shared_species, candidate_area, candidate_au_id))
+
+        if not candidates:
+            continue
+
+        _, _, source_au_id = max(
+            candidates, key=lambda item: (item[0], item[1], item[2])
+        )
+        source_curve = curves_out.loc[curves_out["au_id"] == source_au_id].copy()
+        if source_curve.empty:
+            continue
+        curves_out = curves_out.loc[curves_out["au_id"] != target_au_id].copy()
+        source_curve["au_id"] = target_au_id
+        curves_out = pd.concat(
+            [curves_out, source_curve], ignore_index=True, sort=False
+        )
+        target_mask = diagnostics_out["au_id"] == target_au_id
+        if not target_mask.any():
+            diagnostics_out = pd.concat(
+                [
+                    diagnostics_out,
+                    pd.DataFrame(
+                        [
+                            {
+                                "au_id": target_au_id,
+                                "selected_path": "borrowed_insufficient_support_neighbor",
+                                "accepted": True,
+                                "borrowed_from_au_id": source_au_id,
+                                "borrow_reason": "insufficient_source_stands_same_bec_largest_neighbor",
+                                "source_stand_count": 0,
+                            }
+                        ]
+                    ),
+                ],
+                ignore_index=True,
+                sort=False,
+            )
+        else:
+            diagnostics_out.loc[target_mask, "selected_path"] = (
+                "borrowed_insufficient_support_neighbor"
+            )
+            diagnostics_out.loc[target_mask, "borrowed_from_au_id"] = source_au_id
+            diagnostics_out.loc[target_mask, "borrow_reason"] = (
+                "insufficient_source_stands_same_bec_largest_neighbor"
+            )
+            diagnostics_out.loc[target_mask, "accepted"] = True
+
+    curves_out = curves_out.sort_values(["au_id", "age"], kind="stable").reset_index(
+        drop=True
+    )
+    diagnostics_out = diagnostics_out.sort_values("au_id", kind="stable").reset_index(
+        drop=True
+    )
+    return curves_out, diagnostics_out
+
+
+@dataclass(frozen=True)
+class MkrfAuPlotResult:
+    """Result payload for MKRF AU distribution plot generation."""
+
+    resultant_gdb: Path
+    assignment_csv: Path
+    output_dir: Path
+    png_path: Path
+    pdf_path: Path
+    au_count: int
+    point_count: int
+    metadata: StrataDistributionPlotMetadata
+
+
+@dataclass(frozen=True)
+class MkrfSelectedAuBuildResult:
+    """Result payload for MKRF top-N AU subset publication."""
+
+    au_table_csv: Path
+    assignment_csv: Path
+    output_path: Path
+    target_coverage: float
+    selected_au_count: int
+    total_au_count: int
+    realized_coverage: float
+
+
+@dataclass(frozen=True)
+class MkrfPlotRebuildResult:
+    """Result payload for MKRF diagnostic plot regeneration."""
+
+    output_dir: Path
+    strata_png: Path
+    strata_pdf: Path
+    lmh_plot_count: int
+    fitdiag_plot_count: int
+    tipsy_vdyp_plot_count: int
+
+
+@dataclass(frozen=True)
+class MkrfManagedAuBootstrapResult:
+    """Result payload for MKRF managed AU bootstrap publication."""
+
+    output_dir: Path
+    stand_origin_assignment_path: Path
+    bootstrap_table_path: Path
+    msyt_path: Path
+    selected_au_count: int
+    included_au_count: int
+    unmatched_au_count: int
+    logging_origin_si_au_count: int
+    all_stands_si_fallback_au_count: int
+
+
+@dataclass(frozen=True)
+class MkrfManagedAuCurvesResult:
+    """Result payload for MKRF managed AU BTC attempt."""
+
+    output_dir: Path
+    manifest_path: Path
+    curves_path: Path | None
+    status: str
+    included_au_count: int
+    curve_au_count: int
+
+
+@dataclass(frozen=True)
+class MkrfBadCurveAuditResult:
+    """Result payload for MKRF bad-curve audit publication."""
+
+    output_dir: Path
+    summary_path: Path
+    detail_path: Path
+    flagged_au_count: int
+    total_selected_au_count: int
+
+
+@dataclass(frozen=True)
+class MkrfRuntimePackageInitResult:
+    """Result payload for MKRF canonical runtime-package initialization."""
+
+    package_root: Path
+    readme_path: Path
+    manifest_path: Path
+    curve_status_path: Path
+    analysis_au_runtime_status_path: Path
+    analysis_au_curve_refs_path: Path
+    runtime_au_remap_audit_path: Path
+    species_share_audit_path: Path
+    ct_eligibility_audit_path: Path
+    ct_intensity_audit_path: Path
+    ct_intensity_summary_path: Path
+    hw_ingrowth_overlay_audit_path: Path
+    hw_ingrowth_overlay_summary_path: Path
+    analysis_pin_path: Path
+    headless_runtime_common_path: Path
+    flow_targets_script_path: Path
+    xml_contract_path: Path
+    xml_curve_bank_path: Path
+    forestmodel_xml_path: Path
+    selected_au_count: int
+    first_growth_curve_au_count: int
+    first_growth_missing_au_count: int
+    managed_curve_au_count: int
+
+
+@dataclass(frozen=True)
+class MkrfRuntimeSanityAuditResult:
+    """Result payload for MKRF canonical runtime-sanity auditing."""
+
+    package_root: Path
+    stage_dir: Path
+    audit_csv_path: Path
+    summary_json_path: Path
+    row_count: int
+    failure_count: int
+
+
+@dataclass(frozen=True)
+class MkrfRuntimeSpatialPublishResult:
+    """Result payload for MKRF source-faithful runtime spatial publication."""
+
+    package_root: Path
+    spatial_dir: Path
+    fragments_path: Path
+    manifest_path: Path
+    source_feature_count: int
+    published_feature_count: int
+    excluded_feature_count: int
+
+
+def _manifest_path_value(path: Path | str | None) -> str | None:
+    if path is None:
+        return None
+    candidate = Path(path)
+    try:
+        return os.path.relpath(candidate.resolve(), Path.cwd().resolve()).replace(
+            "\\", "/"
+        )
+    except Exception:
+        return candidate.name
+
+
+_MKRF_RUNTIME_FRAGMENT_FIELD_MAP: tuple[tuple[str, str], ...] = (
+    ("FOREST_COVER_ID", "FOREST_COV"),
+    ("Operability", "Operabilit"),
+    ("Shape_Length", "Shape_Leng"),
+    ("Shape_Area", "Shape_Area"),
+    ("CONTCLAS", "CONTCLAS"),
+    ("AGE_2020", "AGE_2020"),
+    ("AU_EX", "AU_EX"),
+    ("AU_FU", "AU_FU"),
+    ("RES_KEY", "RES_KEY"),
+    ("CT_eligib", "CT_eligib"),
+)
+
+
+def _project_mkrf_runtime_fragments(
+    *, source_gdf: gpd.GeoDataFrame
+) -> gpd.GeoDataFrame:
+    """Project MKRF Resultant rows into the recovered runtime fragments field surface."""
+    missing = sorted(
+        source_name
+        for source_name, _target_name in _MKRF_RUNTIME_FRAGMENT_FIELD_MAP
+        if source_name not in source_gdf.columns
+    )
+    if missing:
+        raise ValueError(
+            "Resultant layer missing required MKRF runtime fragment columns: "
+            + ", ".join(missing)
+        )
+
+    filtered = source_gdf.loc[source_gdf["CONTCLAS"].astype(str) != "X"].copy()
+    projected = gpd.GeoDataFrame(
+        {
+            target_name: filtered[source_name]
+            for source_name, target_name in _MKRF_RUNTIME_FRAGMENT_FIELD_MAP
+        },
+        geometry=filtered.geometry,
+        crs=source_gdf.crs,
+    )
+    return projected
+
+
+def build_mkrf_au_input_bundle(
+    *,
+    resultant_gdb: Path,
+    output_dir: Path,
+    layer: str = "Resultant",
+) -> MkrfAuBuildResult:
+    """Materialize MKRF AU and stand-assignment inputs from Resultant.gdb."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    source_table = gpd.read_file(resultant_gdb, layer=layer, ignore_geometry=True)
+    au_table, assignment = build_mkrf_au_tables(source_table)
+    aggregation_audit = build_mkrf_au_aggregation_audit(assignment)
+
+    au_table_path = output_dir / "au_table.csv"
+    stand_assignment_path = output_dir / "stand_au_assignment.csv"
+    aggregation_audit_path = output_dir / "au_aggregation_audit.csv"
+    au_table.to_csv(au_table_path, index=False)
+    assignment.to_csv(stand_assignment_path, index=False)
+    aggregation_audit.to_csv(aggregation_audit_path, index=False)
+
+    return MkrfAuBuildResult(
+        resultant_gdb=resultant_gdb,
+        output_dir=output_dir,
+        au_table_path=au_table_path,
+        stand_assignment_path=stand_assignment_path,
+        aggregation_audit_path=aggregation_audit_path,
+        source_row_count=len(assignment),
+        au_count=len(au_table),
+    )
+
+
+def publish_mkrf_runtime_spatial_handoff(
+    *,
+    resultant_gdb: Path,
+    package_root: Path,
+    layer: str = "Resultant",
+) -> MkrfRuntimeSpatialPublishResult:
+    """Publish MKRF source-faithful runtime fragments from Resultant.gdb."""
+    package_root = package_root.resolve()
+    spatial_dir = package_root / "spatial"
+    spatial_dir.mkdir(parents=True, exist_ok=True)
+    fragments_path = spatial_dir / "fragments.shp"
+    manifest_path = spatial_dir / "runtime_spatial_manifest.json"
+
+    source_gdf = gpd.read_file(resultant_gdb, layer=layer)
+    source_feature_count = int(len(source_gdf))
+    published_gdf = _project_mkrf_runtime_fragments(source_gdf=source_gdf)
+    published_feature_count = int(len(published_gdf))
+    excluded_feature_count = int(source_feature_count - published_feature_count)
+
+    published_gdf.to_file(fragments_path)
+
+    excluded_rows = source_gdf.loc[source_gdf["CONTCLAS"].astype(str) == "X"].copy()
+    excluded_reason_counts = (
+        excluded_rows["CONTCLAS"].astype(str).value_counts(dropna=False).to_dict()
+        if not excluded_rows.empty
+        else {}
+    )
+    manifest_payload = {
+        "schema_version": 1,
+        "source_layer": layer,
+        "source_resultant_gdb": str(resultant_gdb.resolve()),
+        "publication_rule": "CONTCLAS != 'X'",
+        "field_projection": [
+            {"source": source_name, "target": target_name}
+            for source_name, target_name in _MKRF_RUNTIME_FRAGMENT_FIELD_MAP
+        ],
+        "package_root": str(package_root),
+        "fragments_path": str(fragments_path.resolve()),
+        "source_feature_count": source_feature_count,
+        "published_feature_count": published_feature_count,
+        "excluded_feature_count": excluded_feature_count,
+        "excluded_reason_counts": excluded_reason_counts,
+    }
+    manifest_path.write_text(
+        json.dumps(manifest_payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    return MkrfRuntimeSpatialPublishResult(
+        package_root=package_root,
+        spatial_dir=spatial_dir,
+        fragments_path=fragments_path,
+        manifest_path=manifest_path,
+        source_feature_count=source_feature_count,
+        published_feature_count=published_feature_count,
+        excluded_feature_count=excluded_feature_count,
+    )
+
+
+def build_mkrf_first_growth_input_bundle(
+    *,
+    vdyp_yields_csv: Path,
+    assignment_csv: Path,
+    output_dir: Path,
+    resultant_gdb: Path,
+    layer: str = "Resultant",
+) -> MkrfFirstGrowthBuildResult:
+    """Materialize MKRF AU-wise first-growth curves from VDYP stand evidence."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    vdyp_yields = pd.read_csv(vdyp_yields_csv)
+    assignment = pd.read_csv(assignment_csv)
+    source_table = gpd.read_file(resultant_gdb, layer=layer, ignore_geometry=True)
+    curves, diagnostics = build_mkrf_first_growth_curves(
+        vdyp_yields=vdyp_yields,
+        assignment=assignment,
+        source_table=source_table,
+    )
+
+    curves_path = output_dir / "first_growth_au_curves.csv"
+    diagnostics_path = output_dir / "first_growth_au_fit_diagnostics.csv"
+    curves.to_csv(curves_path, index=False)
+    diagnostics.to_csv(diagnostics_path, index=False)
+    vdyp_feature_ids = _resolve_eligible_first_growth_feature_ids(
+        vdyp_yields=vdyp_yields,
+        source_table=source_table,
+        min_first_growth_age=80.0,
+    )
+    assigned_feature_ids = set(
+        pd.to_numeric(assignment["forest_cover_id"], errors="coerce")
+        .dropna()
+        .astype(int)
+    )
+    raw_unmatched_feature_ids = vdyp_feature_ids - assigned_feature_ids
+    source_feature_ids = set(
+        pd.to_numeric(source_table["FOREST_COVER_ID"], errors="coerce")
+        .dropna()
+        .astype(int)
+    )
+    residual_unmatched_feature_ids = raw_unmatched_feature_ids - source_feature_ids
+
+    return MkrfFirstGrowthBuildResult(
+        vdyp_yields_csv=vdyp_yields_csv,
+        assignment_csv=assignment_csv,
+        output_dir=output_dir,
+        curves_path=curves_path,
+        diagnostics_path=diagnostics_path,
+        au_count=int(diagnostics["au_id"].nunique()),
+        assigned_stand_count=int(diagnostics["source_stand_count"].sum()),
+        raw_unmatched_source_stand_count=int(len(raw_unmatched_feature_ids)),
+        residual_unmatched_source_stand_count=int(len(residual_unmatched_feature_ids)),
+        lexmatch_assigned_stand_count=int(diagnostics["lexmatch_stand_count"].sum()),
+    )
+
+
+def _format_mkrf_au_label(au_id: str) -> str:
+    parts = str(au_id).split("_")
+    if len(parts) != 5:
+        return str(au_id).upper()
+    bec_zone, bec_subzone, bec_variant, sp1, sp2 = parts
+    bec = f"{bec_zone.upper()}{bec_subzone}{bec_variant}"
+    return f"{bec}_{sp1.upper()}+{sp2.upper()}"
+
+
+def build_mkrf_au_distribution_plot(
+    *,
+    resultant_gdb: Path,
+    assignment_csv: Path,
+    selected_au_csv: Path | None = None,
+    output_dir: Path,
+    layer: str = "Resultant",
+    tsa_code: str = "mkrf",
+) -> MkrfAuPlotResult:
+    """Render the MKRF AU abundance/site-index distribution plot."""
+    import matplotlib.pyplot as plt
+    import seaborn as sns
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    assignment = pd.read_csv(assignment_csv)
+    if selected_au_csv is not None:
+        selected_au_table = pd.read_csv(selected_au_csv)
+        assignment = _filter_assignment_to_selected_aus(
+            assignment,
+            selected_au_table,
+        )
+    source_table = gpd.read_file(resultant_gdb, layer=layer, ignore_geometry=True)
+    source_subset = source_table[["RES_KEY", "TCL_1_ESTIMATED_SITE_INDEX"]].copy()
+    source_subset = source_subset.rename(
+        columns={
+            "RES_KEY": "res_key",
+            "TCL_1_ESTIMATED_SITE_INDEX": "SITE_INDEX",
+        }
+    )
+    plot_frame = assignment.merge(source_subset, on="res_key", how="left")
+    plot_frame["SITE_INDEX"] = pd.to_numeric(plot_frame["SITE_INDEX"], errors="coerce")
+
+    abundance = (
+        assignment.groupby("au_id", as_index=True)["shape_area_ha"]
+        .sum()
+        .sort_values(ascending=False)
+    )
+    strata_df = pd.DataFrame(
+        {
+            "totalarea_p": abundance / float(abundance.sum()),
+            "site_index_median": plot_frame.groupby("au_id")["SITE_INDEX"]
+            .median()
+            .reindex(abundance.index),
+        }
+    )
+
+    stratum_props, labels_raw = resolve_strata_plot_ordering(
+        strata_df=strata_df,
+        sort_lex=False,
+    )
+    label_map = {label: _format_mkrf_au_label(label) for label in labels_raw}
+    labels = [label_map[label] for label in labels_raw]
+    plot_frame["au_label"] = plot_frame["au_id"].map(label_map)
+
+    plot_config = build_strata_distribution_plot_config(
+        site_index_xlim=(0, 50),
+        write_pdf=True,
+    )
+    metadata = render_strata_distribution_plot(
+        tsa_code=tsa_code,
+        f_table=plot_frame[["au_label", "SITE_INDEX"]].rename(
+            columns={"au_label": "au_id"}
+        ),
+        stratum_col="au_id",
+        labels=labels,
+        stratum_props=stratum_props,
+        plot_config=plot_config,
+        sns_module=sns,
+        plt_module=plt,
+        strata_plot_paths_fn=lambda _tsa: strata_plot_paths(_tsa, root=output_dir),
+    )
+    pdf_path, png_path = strata_plot_paths(tsa_code, root=output_dir)
+    plt.close("all")
+    return MkrfAuPlotResult(
+        resultant_gdb=resultant_gdb,
+        assignment_csv=assignment_csv,
+        output_dir=output_dir,
+        png_path=png_path,
+        pdf_path=pdf_path,
+        au_count=int(assignment["au_id"].nunique()),
+        point_count=int(plot_frame["SITE_INDEX"].notna().sum()),
+        metadata=metadata,
+    )
+
+
+def _build_selected_au_label_map(selected_au_table: pd.DataFrame) -> dict[str, str]:
+    ordered = selected_au_table.sort_values(["selected_rank", "au_id"], kind="stable")
+    labels: dict[str, str] = {}
+    for _, row in ordered.iterrows():
+        au_id = str(row["au_id"])
+        rank = int(row["selected_rank"]) - 1
+        labels[au_id] = f"{rank:02d}-{_format_mkrf_au_label(au_id)}"
+    return labels
+
+
+def _filter_assignment_to_selected_aus(
+    assignment: pd.DataFrame,
+    selected_au_table: pd.DataFrame,
+) -> pd.DataFrame:
+    selected_ids = set(selected_au_table["au_id"].astype(str))
+    return assignment.loc[assignment["au_id"].astype(str).isin(selected_ids)].copy()
+
+
+def _classify_site_index_levels(site_index: pd.Series) -> pd.Series:
+    numeric = pd.to_numeric(site_index, errors="coerce")
+    valid = numeric.dropna()
+    if valid.empty:
+        return pd.Series(index=site_index.index, dtype="object")
+    if len(valid) == 1 or valid.nunique() == 1:
+        labeled = pd.Series("M", index=valid.index, dtype="object")
+    else:
+        quantile_count = min(3, int(valid.nunique()))
+        labels = (
+            ["M"]
+            if quantile_count == 1
+            else (["L", "H"] if quantile_count == 2 else ["L", "M", "H"])
+        )
+        ranked = valid.rank(method="first")
+        labeled = pd.qcut(ranked, q=quantile_count, labels=labels).astype("object")
+    return labeled.reindex(site_index.index)
+
+
+def _extract_feature_curve_tables(vdyp_rows: pd.DataFrame) -> dict[int, pd.DataFrame]:
+    tables: dict[int, pd.DataFrame] = {}
+    for feature_id, feature_rows in vdyp_rows.groupby("FEATURE_ID", sort=True):
+        ordered = feature_rows.sort_values("PRJ_TOTAL_AGE", kind="stable").rename(
+            columns={"PRJ_TOTAL_AGE": "Age", "PRJ_VOL_DWB": "Vdwb"}
+        )
+        tables[int(feature_id)] = ordered[["Age", "Vdwb"]].set_index("Age")
+    return tables
+
+
+def _build_fitdiag_summary(raw_subset: pd.DataFrame) -> pd.DataFrame:
+    table = raw_subset.rename(
+        columns={"PRJ_TOTAL_AGE": "Age", "PRJ_VOL_DWB": "Vdwb"}
+    ).copy()
+    table["Age"] = pd.to_numeric(table["Age"], errors="coerce")
+    table["Vdwb"] = pd.to_numeric(table["Vdwb"], errors="coerce")
+    table = table.dropna(subset=["Age", "Vdwb"])
+    table = table.loc[
+        (table["Age"] >= 30) & (table["Age"] <= 350) & (table["Vdwb"] >= 0)
+    ]
+    if table.empty:
+        return pd.DataFrame(columns=["age_bin", "median_volume", "p25", "p75"])
+    table["age_bin"] = (np.floor(table["Age"] / 5.0) * 5.0).astype(float)
+    return (
+        table.groupby("age_bin", as_index=False)
+        .agg(
+            median_volume=("Vdwb", "median"),
+            p25=("Vdwb", lambda s: float(s.quantile(0.25))),
+            p75=("Vdwb", lambda s: float(s.quantile(0.75))),
+        )
+        .sort_values("age_bin", kind="stable")
+        .reset_index(drop=True)
+    )
+
+
+def _fitdiag_plot_path(
+    *, output_dir: Path, tsa_code: str, au_label: str, level: str
+) -> Path:
+    tsa = str(tsa_code).zfill(2)
+    return output_dir / f"vdyp_fitdiag_tsa{tsa}-{au_label}-{level}.png"
+
+
+def _lmh_plot_path(*, output_dir: Path, tsa_code: str, au_label: str) -> Path:
+    tsa = str(tsa_code).zfill(2)
+    return output_dir / f"vdyp_lmh_tsa{tsa}-{au_label}.png"
+
+
+def _tipsy_vdyp_plot_path(*, output_dir: Path, tsa_code: str, au_label: str) -> Path:
+    tsa = str(tsa_code).zfill(2)
+    return output_dir / f"tipsy_vdyp_tsa{tsa}-{au_label}.png"
+
+
+def build_mkrf_selected_au_input_bundle(
+    *,
+    au_table_csv: Path,
+    assignment_csv: Path,
+    output_path: Path,
+    target_coverage: float = 0.95,
+) -> MkrfSelectedAuBuildResult:
+    """Publish the canonical top-N AU subset by cumulative covered-area share."""
+    au_table = pd.read_csv(au_table_csv)
+    assignment = pd.read_csv(assignment_csv)
+    selected = build_mkrf_selected_au_table(
+        au_table=au_table,
+        assignment=assignment,
+        target_coverage=target_coverage,
+    )
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    selected.to_csv(output_path, index=False)
+    realized_coverage = (
+        float(selected["cumulative_covered_area_share"].iloc[-1])
+        if not selected.empty
+        else 0.0
+    )
+    return MkrfSelectedAuBuildResult(
+        au_table_csv=au_table_csv,
+        assignment_csv=assignment_csv,
+        output_path=output_path,
+        target_coverage=float(target_coverage),
+        selected_au_count=int(len(selected)),
+        total_au_count=int(len(au_table)),
+        realized_coverage=realized_coverage,
+    )
+
+
+def build_mkrf_managed_au_input_bundle(
+    *,
+    resultant_gdb: Path,
+    selected_au_csv: Path,
+    assignment_csv: Path,
+    tipsy_rules_yaml: Path,
+    output_dir: Path,
+    layer: str = "Resultant",
+) -> MkrfManagedAuBootstrapResult:
+    """Build the expert-rule managed AU bootstrap and BTC MSYT input tables."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    selected_au_table = pd.read_csv(selected_au_csv)
+    assignment = pd.read_csv(assignment_csv)
+    source_table = gpd.read_file(resultant_gdb, layer=layer, ignore_geometry=True)
+    rule_config = load_mkrf_managed_rule_config(tipsy_rules_yaml)
+    stand_origin_assignment = build_mkrf_stand_origin_assignment(
+        assignment=assignment,
+        source_table=source_table,
+        fire_origin_min_age=rule_config.fire_origin_min_age,
+    )
+    stand_origin_assignment_path = output_dir / "stand_origin_assignment.csv"
+    stand_origin_assignment.to_csv(stand_origin_assignment_path, index=False)
+
+    bootstrap_table = build_mkrf_managed_au_bootstrap_table(
+        selected_au_table=selected_au_table,
+        stand_origin_assignment=stand_origin_assignment,
+        rule_config=rule_config,
+    )
+    bootstrap_path = output_dir / "managed_au_bootstrap_table.csv"
+    bootstrap_table.to_csv(bootstrap_path, index=False)
+
+    msyt_table = build_mkrf_managed_au_msyt_table(bootstrap_table=bootstrap_table)
+    msyt_path = output_dir / "managed_au_msyt.csv"
+    msyt_table.to_csv(msyt_path, index=False)
+
+    included = bootstrap_table["included_in_msyt"].fillna(False)
+    return MkrfManagedAuBootstrapResult(
+        output_dir=output_dir,
+        stand_origin_assignment_path=stand_origin_assignment_path,
+        bootstrap_table_path=bootstrap_path,
+        msyt_path=msyt_path,
+        selected_au_count=int(len(selected_au_table)),
+        included_au_count=int(included.sum()),
+        unmatched_au_count=int(
+            (bootstrap_table["bootstrap_status"] == "unmatched").sum()
+        ),
+        logging_origin_si_au_count=int(
+            (bootstrap_table["managed_si_source"] == "logging_origin_median").sum()
+        ),
+        all_stands_si_fallback_au_count=int(
+            (bootstrap_table["managed_si_source"] == "all_stands_median").sum()
+        ),
+    )
+
+
+def build_mkrf_managed_au_curves(
+    *,
+    bootstrap_csv: Path,
+    msyt_csv: Path,
+    output_dir: Path,
+    log_dir: Path,
+    run_id: str = "mkrf_managed_au_curves",
+    executable_path: Path | None = None,
+) -> MkrfManagedAuCurvesResult:
+    """Attempt a BTC compile for the provisional managed AU lane."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    log_dir.mkdir(parents=True, exist_ok=True)
+    bootstrap_table = pd.read_csv(bootstrap_csv)
+    manifest_path = output_dir / "managed_au_run_manifest.json"
+    included_count = int(bootstrap_table["included_in_msyt"].fillna(False).sum())
+    try:
+        btc_result = run_btc_cli(
+            input_csv=msyt_csv,
+            mode="TSR",
+            executable_path=executable_path,
+            report_preset_name="tsr-unattended-default",
+            log_dir=log_dir,
+            run_id=run_id,
+        )
+    except FileNotFoundError as exc:
+        write_mkrf_managed_run_manifest(
+            manifest_path=manifest_path,
+            payload={
+                "status": "blocked",
+                "reason": "missing_btc_runtime",
+                "message": str(exc),
+                "msyt_csv": _manifest_path_value(msyt_csv),
+                "bootstrap_csv": _manifest_path_value(bootstrap_csv),
+                "included_au_count": included_count,
+            },
+        )
+        return MkrfManagedAuCurvesResult(
+            output_dir=output_dir,
+            manifest_path=manifest_path,
+            curves_path=None,
+            status="blocked",
+            included_au_count=included_count,
+            curve_au_count=0,
+        )
+
+    curves = parse_mkrf_managed_au_curves(
+        output_csv=btc_result.output_csv_path,
+        bootstrap_table=bootstrap_table,
+    )
+    curves_path = output_dir / "managed_au_curves.csv"
+    curves.to_csv(curves_path, index=False)
+    write_mkrf_managed_run_manifest(
+        manifest_path=manifest_path,
+        payload={
+            "status": "completed",
+            "msyt_csv": _manifest_path_value(msyt_csv),
+            "bootstrap_csv": _manifest_path_value(bootstrap_csv),
+            "curves_csv": _manifest_path_value(curves_path),
+            "included_au_count": included_count,
+            "curve_au_count": int(curves["au_id"].nunique()),
+            "btc_manifest_path": _manifest_path_value(btc_result.manifest_path),
+            "btc_stdout_log_path": _manifest_path_value(btc_result.stdout_log_path),
+            "btc_stderr_log_path": _manifest_path_value(btc_result.stderr_log_path),
+            "btc_output_csv_path": _manifest_path_value(btc_result.output_csv_path),
+            "btc_error_csv_path": _manifest_path_value(btc_result.error_csv_path),
+        },
+    )
+    return MkrfManagedAuCurvesResult(
+        output_dir=output_dir,
+        manifest_path=manifest_path,
+        curves_path=curves_path,
+        status="completed",
+        included_au_count=included_count,
+        curve_au_count=int(curves["au_id"].nunique()),
+    )
+
+
+def build_mkrf_all_plots(
+    *,
+    resultant_gdb: Path,
+    assignment_csv: Path,
+    selected_au_csv: Path,
+    first_growth_curves_csv: Path,
+    vdyp_yields_csv: Path,
+    managed_curves_csv: Path,
+    output_dir: Path,
+    layer: str = "Resultant",
+    tsa_code: str = "mkrf",
+) -> MkrfPlotRebuildResult:
+    """Recompile MKRF diagnostic and comparison plots for the selected AU subset."""
+    import matplotlib.pyplot as plt
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    for pattern in (
+        "strata-tsa*.png",
+        "strata-tsa*.pdf",
+        "vdyp_lmh_tsa*.png",
+        "vdyp_fitdiag_tsa*.png",
+        "tipsy_vdyp_tsa*.png",
+    ):
+        for path in output_dir.glob(pattern):
+            path.unlink()
+    strata = build_mkrf_au_distribution_plot(
+        resultant_gdb=resultant_gdb,
+        assignment_csv=assignment_csv,
+        selected_au_csv=selected_au_csv,
+        output_dir=output_dir,
+        layer=layer,
+        tsa_code=tsa_code,
+    )
+
+    assignment = pd.read_csv(assignment_csv)
+    selected_au_table = pd.read_csv(selected_au_csv)
+    first_growth_curves = pd.read_csv(first_growth_curves_csv)
+    managed_curves = pd.read_csv(managed_curves_csv)
+    vdyp_yields = pd.read_csv(vdyp_yields_csv)
+    source_table = gpd.read_file(resultant_gdb, layer=layer, ignore_geometry=True)
+
+    selected_ids = list(
+        selected_au_table.sort_values(["selected_rank", "au_id"], kind="stable")[
+            "au_id"
+        ]
+    )
+    label_map = _build_selected_au_label_map(selected_au_table)
+
+    stand_assignment = collapse_stand_assignments(assignment).rename(
+        columns={"dominant_weight": "shape_area_ha"}
+    )
+    stand_assignment = stand_assignment.merge(
+        source_table[["FOREST_COVER_ID", "TCL_1_ESTIMATED_SITE_INDEX"]]
+        .drop_duplicates("FOREST_COVER_ID")
+        .rename(
+            columns={
+                "FOREST_COVER_ID": "forest_cover_id",
+                "TCL_1_ESTIMATED_SITE_INDEX": "site_index",
+            }
+        ),
+        on="forest_cover_id",
+        how="left",
+    )
+    stand_assignment["site_index"] = pd.to_numeric(
+        stand_assignment["site_index"], errors="coerce"
+    )
+    stand_assignment = stand_assignment.loc[
+        stand_assignment["au_id"].isin(selected_ids)
+    ].copy()
+
+    level_assignment_rows: list[dict[str, object]] = []
+    stand_level_map: dict[tuple[str, str], list[int]] = {}
+    canonical_median_si: dict[str, float] = {}
+    for au_id, au_rows in stand_assignment.groupby("au_id", sort=True):
+        level_series = _classify_site_index_levels(au_rows["site_index"])
+        au_rows = au_rows.assign(si_level=level_series.values)
+        canonical_median_si[str(au_id)] = float(au_rows["site_index"].median())
+        for level, level_rows in au_rows.dropna(subset=["si_level"]).groupby(
+            "si_level", sort=True
+        ):
+            temp_au_id = f"{au_id}__{level}"
+            stand_level_map[(str(au_id), str(level))] = [
+                int(v) for v in level_rows["forest_cover_id"].tolist()
+            ]
+            for _, row in level_rows.iterrows():
+                level_assignment_rows.append(
+                    {
+                        "res_key": int(row["forest_cover_id"]),
+                        "forest_cover_id": int(row["forest_cover_id"]),
+                        "shape_area_ha": float(row["shape_area_ha"]),
+                        "au_id": temp_au_id,
+                    }
+                )
+
+    lmh_curves = pd.DataFrame(columns=["au_id", "age", "volume"])
+    lmh_diagnostics = pd.DataFrame(columns=["au_id", "rmse", "mape", "tail_rmse"])
+    eligible_first_growth_feature_ids = _resolve_eligible_first_growth_feature_ids(
+        vdyp_yields=vdyp_yields,
+        source_table=source_table,
+        min_first_growth_age=80.0,
+    )
+    if level_assignment_rows:
+        level_assignment = pd.DataFrame(level_assignment_rows)
+        lmh_curves, lmh_diagnostics = build_mkrf_first_growth_curves(
+            vdyp_yields=vdyp_yields.loc[
+                vdyp_yields["FEATURE_ID"].isin(level_assignment["forest_cover_id"])
+            ].copy(),
+            assignment=level_assignment,
+            source_table=source_table,
+        )
+
+    lmh_plot_count = 0
+    fitdiag_plot_count = 0
+    for au_id in selected_ids:
+        label = label_map[str(au_id)]
+        au_curves = lmh_curves.loc[
+            lmh_curves["au_id"].astype(str).str.startswith(f"{au_id}__")
+        ].copy()
+        if au_curves.empty:
+            continue
+
+        fig, ax = plt.subplots(1, 1, figsize=(8, 5))
+        ymax = 1.0
+        plotted = False
+        for level, color in (("L", "tab:blue"), ("M", "tab:green"), ("H", "tab:red")):
+            temp_au_id = f"{au_id}__{level}"
+            curve = au_curves.loc[au_curves["au_id"] == temp_au_id]
+            if curve.empty:
+                continue
+            plotted = True
+            ax.plot(
+                curve["age"], curve["volume"], linewidth=2.0, color=color, label=level
+            )
+            ymax = max(ymax, float(curve["volume"].max()))
+        if plotted:
+            ax.set_title(f"VDYP L/M/H Comparison: {label}")
+            ax.set_xlabel("Age")
+            ax.set_ylabel("Volume (m3/ha)")
+            ax.set_xlim(0, 300)
+            ax.set_ylim(0, ymax * 1.05)
+            ax.grid(alpha=0.25)
+            ax.legend(fontsize=8)
+            fig.tight_layout()
+            fig.savefig(
+                _lmh_plot_path(
+                    output_dir=output_dir, tsa_code=tsa_code, au_label=label
+                ),
+                dpi=150,
+            )
+            lmh_plot_count += 1
+        plt.close(fig)
+
+        for level in ("L", "M", "H"):
+            temp_au_id = f"{au_id}__{level}"
+            curve = au_curves.loc[au_curves["au_id"] == temp_au_id]
+            if curve.empty:
+                continue
+            stand_ids = [
+                stand_id
+                for stand_id in stand_level_map.get((str(au_id), level), [])
+                if stand_id in eligible_first_growth_feature_ids
+            ]
+            if not stand_ids:
+                continue
+            raw_subset = vdyp_yields.loc[
+                vdyp_yields["FEATURE_ID"].isin(stand_ids)
+            ].copy()
+            feature_tables = _extract_feature_curve_tables(raw_subset)
+            if not feature_tables:
+                continue
+            observed = _build_fitdiag_summary(raw_subset)
+            diag_matches = lmh_diagnostics.loc[lmh_diagnostics["au_id"] == temp_au_id]
+            if diag_matches.empty:
+                continue
+            diag_row = diag_matches.iloc[0]
+            fig, (ax, ax_resid) = plt.subplots(
+                2,
+                1,
+                figsize=(8, 8),
+                sharex=True,
+                gridspec_kw={"height_ratios": [3, 1]},
+            )
+            raw_label_used = False
+            for table in feature_tables.values():
+                raw = table.reset_index().dropna()
+                raw = raw.loc[
+                    (raw["Age"] >= 0) & (raw["Age"] <= 350) & (raw["Vdwb"] >= 0)
+                ]
+                if raw.empty:
+                    continue
+                ax.plot(
+                    raw["Age"],
+                    raw["Vdwb"],
+                    color="0.5",
+                    alpha=0.08,
+                    linewidth=0.4,
+                    label="Raw VDYP curves" if not raw_label_used else None,
+                    zorder=1,
+                )
+                raw_label_used = True
+            if not observed.empty:
+                ax.fill_between(
+                    observed["age_bin"],
+                    observed["p25"],
+                    observed["p75"],
+                    color="lightblue",
+                    alpha=0.35,
+                    label="Observed P25-P75 (5y bins)",
+                )
+                ax.scatter(
+                    observed["age_bin"],
+                    observed["median_volume"],
+                    s=14,
+                    color="tab:blue",
+                    label="Observed median (5y bins)",
+                )
+            ax.plot(
+                curve["age"],
+                curve["volume"],
+                color="black",
+                linewidth=2.2,
+                label="Selected fit",
+            )
+            ax.set_title(f"VDYP Fit Diagnostic: {label} {level}")
+            ax.set_xlabel("Age")
+            ax.set_ylabel("Volume (m3/ha)")
+            ax.set_xlim(0, 300)
+            ymax = max(
+                float(curve["volume"].max()) * 1.05,
+                float(observed["p75"].max()) * 1.15 if not observed.empty else 1.0,
+                1.0,
+            )
+            ax.set_ylim(0, ymax)
+            ax.grid(alpha=0.25)
+            ax.legend(fontsize=8)
+            ax.text(
+                0.01,
+                0.99,
+                "\n".join(
+                    [
+                        f"rmse={float(diag_row['rmse']):.1f}",
+                        f"mape={float(diag_row['mape']):.3f}",
+                        f"tail_rmse={float(diag_row['tail_rmse']):.1f}",
+                        f"stands={int(diag_row['source_stand_count'])}",
+                    ]
+                ),
+                transform=ax.transAxes,
+                ha="left",
+                va="top",
+                fontsize=7,
+                bbox={"facecolor": "white", "alpha": 0.75, "edgecolor": "none"},
+            )
+            if not observed.empty:
+                predicted = np.interp(
+                    observed["age_bin"].to_numpy(dtype=float),
+                    curve["age"].to_numpy(dtype=float),
+                    curve["volume"].to_numpy(dtype=float),
+                )
+                residual = predicted - observed["median_volume"].to_numpy(dtype=float)
+                ax_resid.axhline(0.0, color="black", linewidth=1.0, alpha=0.6)
+                ax_resid.scatter(
+                    observed["age_bin"],
+                    residual,
+                    s=14,
+                    color="tab:gray",
+                    alpha=0.8,
+                )
+                ax_resid.plot(
+                    observed["age_bin"],
+                    residual,
+                    color="tab:gray",
+                    linewidth=1.2,
+                    alpha=0.7,
+                )
+            ax_resid.set_ylabel("Residual")
+            ax_resid.set_xlabel("Age")
+            ax_resid.grid(alpha=0.25)
+            fig.tight_layout()
+            fig.savefig(
+                _fitdiag_plot_path(
+                    output_dir=output_dir,
+                    tsa_code=tsa_code,
+                    au_label=label,
+                    level=level,
+                ),
+                dpi=150,
+            )
+            fitdiag_plot_count += 1
+            plt.close(fig)
+
+    tipsy_vdyp_plot_count = 0
+    for au_id in selected_ids:
+        label = label_map[str(au_id)]
+        tipsy_curve = managed_curves.loc[managed_curves["au_id"] == str(au_id)].copy()
+        vdyp_curve = first_growth_curves.loc[
+            first_growth_curves["au_id"] == str(au_id)
+        ].copy()
+        if tipsy_curve.empty or vdyp_curve.empty:
+            continue
+        fig, ax = plt.subplots(1, 1, figsize=(8, 6))
+        ax.plot(
+            vdyp_curve["age"],
+            vdyp_curve["volume"],
+            color="black",
+            linewidth=2.0,
+            label="VDYP first-growth",
+        )
+        ax.plot(
+            pd.to_numeric(tipsy_curve["age"], errors="coerce"),
+            pd.to_numeric(tipsy_curve["volume"], errors="coerce"),
+            color="tab:green",
+            linewidth=2.0,
+            linestyle="--",
+            label="TIPSY managed",
+        )
+        ymax = max(
+            float(vdyp_curve["volume"].max()),
+            float(pd.to_numeric(tipsy_curve["volume"], errors="coerce").max()),
+            1.0,
+        )
+        ax.set_title(f"TIPSY vs VDYP: {label}")
+        ax.set_xlabel("Age")
+        ax.set_ylabel("Yield (m3/ha)")
+        ax.set_xlim(0, 300)
+        ax.set_ylim(0, ymax * 1.05)
+        ax.grid(alpha=0.25)
+        ax.legend(fontsize=8)
+        fig.tight_layout()
+        fig.savefig(
+            _tipsy_vdyp_plot_path(
+                output_dir=output_dir, tsa_code=tsa_code, au_label=label
+            ),
+            dpi=150,
+        )
+        tipsy_vdyp_plot_count += 1
+        plt.close(fig)
+
+    return MkrfPlotRebuildResult(
+        output_dir=output_dir,
+        strata_png=strata.png_path,
+        strata_pdf=strata.pdf_path,
+        lmh_plot_count=lmh_plot_count,
+        fitdiag_plot_count=fitdiag_plot_count,
+        tipsy_vdyp_plot_count=tipsy_vdyp_plot_count,
+    )
+
+
+def build_mkrf_bad_curve_audit(
+    *,
+    resultant_gdb: Path,
+    assignment_csv: Path,
+    selected_au_csv: Path,
+    first_growth_curves_csv: Path,
+    vdyp_yields_csv: Path,
+    output_dir: Path,
+    layer: str = "Resultant",
+    low_terminal_threshold: float = 100.0,
+    large_area_threshold: float = 50.0,
+    low_large_area_threshold: float = 200.0,
+    low_terminal_stand_threshold: float = 20.0,
+    high_terminal_stand_threshold: float = 300.0,
+) -> MkrfBadCurveAuditResult:
+    """Audit bad first-growth curve cases against source-stand evidence."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    assignment = pd.read_csv(assignment_csv)
+    selected_au_table = pd.read_csv(selected_au_csv)
+    first_growth_curves = pd.read_csv(first_growth_curves_csv)
+    vdyp_yields = pd.read_csv(vdyp_yields_csv)
+    source_table = gpd.read_file(resultant_gdb, layer=layer, ignore_geometry=True)
+
+    terminal_curves = (
+        first_growth_curves.sort_values(["au_id", "age"], kind="stable")
+        .groupby("au_id", as_index=False)
+        .tail(1)[["au_id", "age", "volume"]]
+        .rename(columns={"age": "terminal_age", "volume": "terminal_volume"})
+    )
+    selected = selected_au_table.merge(terminal_curves, on="au_id", how="left")
+
+    source_subset = source_table.copy()
+    source_subset["forest_cover_id"] = pd.to_numeric(
+        source_subset["FOREST_COVER_ID"], errors="coerce"
+    )
+    keep_columns = {
+        "forest_cover_id",
+        "TCL_1_ESTIMATED_SITE_INDEX",
+        "AGE_2020",
+        "BEC_ZONE_CODE",
+        "BEC_SUBZONE",
+        "BEC_VARIANT",
+    }
+    source_subset = source_subset[
+        [c for c in source_subset.columns if c in keep_columns]
+    ].copy()
+    terminal_stands = (
+        vdyp_yields.sort_values(["FEATURE_ID", "PRJ_TOTAL_AGE"], kind="stable")
+        .groupby("FEATURE_ID", as_index=False)
+        .tail(1)[["FEATURE_ID", "PRJ_TOTAL_AGE", "PRJ_VOL_DWB"]]
+        .rename(
+            columns={
+                "FEATURE_ID": "forest_cover_id",
+                "PRJ_TOTAL_AGE": "terminal_vdyp_age",
+                "PRJ_VOL_DWB": "terminal_vdyp_volume",
+            }
+        )
+    )
+
+    detail_rows: list[dict[str, object]] = []
+    summary_rows: list[dict[str, object]] = []
+    for _, selected_row in selected.sort_values(
+        ["selected_rank", "au_id"], kind="stable"
+    ).iterrows():
+        au_id = str(selected_row["au_id"])
+        assignment_rows = assignment.loc[
+            assignment["au_id"].astype(str) == au_id
+        ].copy()
+        joined = assignment_rows.merge(
+            source_subset, on="forest_cover_id", how="left"
+        ).merge(
+            terminal_stands,
+            on="forest_cover_id",
+            how="left",
+        )
+        si = pd.to_numeric(joined.get("TCL_1_ESTIMATED_SITE_INDEX"), errors="coerce")
+        age = pd.to_numeric(joined.get("AGE_2020"), errors="coerce")
+        terminal = pd.to_numeric(joined.get("terminal_vdyp_volume"), errors="coerce")
+        stand_count = int(len(joined))
+        valid_age = age.dropna()
+        old_support_stand_count = int(
+            joined.loc[
+                pd.to_numeric(joined.get("AGE_2020"), errors="coerce") >= 80.0,
+                "forest_cover_id",
+            ]
+            .dropna()
+            .astype(int)
+            .nunique()
+        )
+
+        def _share(count: int) -> float:
+            if stand_count == 0:
+                return 0.0
+            return float(count) / float(stand_count)
+
+        age_lt_20_count = int((valid_age < 20.0).sum())
+        age_lt_30_count = int((valid_age < 30.0).sum())
+        age_lt_80_count = int((valid_age < 80.0).sum())
+        age_gte_80_count = int((valid_age >= 80.0).sum())
+
+        low_count = int((terminal.fillna(0.0) < low_terminal_stand_threshold).sum())
+        high_count = int((terminal.fillna(0.0) > high_terminal_stand_threshold).sum())
+        if low_count > 0 and high_count > 0:
+            pattern = "mixed_low_high"
+        elif low_count > 0:
+            pattern = "mostly_low"
+        elif high_count > 0:
+            pattern = "mostly_high"
+        else:
+            pattern = "midrange"
+
+        terminal_volume = pd.to_numeric(
+            selected_row["terminal_volume"], errors="coerce"
+        )
+        initial_flag = (
+            float(
+                pd.to_numeric(
+                    pd.Series([selected_row["terminal_volume"]]), errors="coerce"
+                )
+                .fillna(0.0)
+                .iloc[0]
+            )
+            < low_terminal_threshold
+        ) or (
+            float(
+                pd.to_numeric(
+                    pd.Series([selected_row["covered_area_ha"]]), errors="coerce"
+                )
+                .fillna(0.0)
+                .iloc[0]
+            )
+            > large_area_threshold
+            and float(
+                pd.to_numeric(
+                    pd.Series([selected_row["terminal_volume"]]), errors="coerce"
+                )
+                .fillna(0.0)
+                .iloc[0]
+            )
+            < low_large_area_threshold
+        )
+        if pd.isna(terminal_volume):
+            if age_gte_80_count == 0:
+                issue_class = "managed_only_after_age_floor"
+            elif old_support_stand_count < _MIN_FIRST_GROWTH_SOURCE_STANDS:
+                issue_class = "insufficient_source_stands"
+            else:
+                issue_class = "missing_first_growth_curve"
+        elif low_count > 0 and high_count > 0:
+            issue_class = "mixed_population"
+        elif _share(age_lt_80_count) >= 0.5:
+            issue_class = "young_skewed_population"
+        else:
+            issue_class = "persistently_low_old_unit"
+
+        flagged = bool(initial_flag)
+        if issue_class == "managed_only_after_age_floor":
+            flagged = False
+
+        summary_rows.append(
+            {
+                "selected_rank": int(selected_row["selected_rank"]),
+                "au_id": au_id,
+                "covered_area_ha": float(selected_row["covered_area_ha"]),
+                "terminal_age": float(selected_row["terminal_age"]),
+                "terminal_volume": float(selected_row["terminal_volume"]),
+                "flagged": flagged,
+                "stand_count": stand_count,
+                "site_index_min": float(si.min()) if len(si.dropna()) else np.nan,
+                "site_index_median": float(si.median()) if len(si.dropna()) else np.nan,
+                "site_index_max": float(si.max()) if len(si.dropna()) else np.nan,
+                "age_2020_min": float(age.min()) if len(age.dropna()) else np.nan,
+                "age_2020_median": float(age.median()) if len(age.dropna()) else np.nan,
+                "age_2020_max": float(age.max()) if len(age.dropna()) else np.nan,
+                "age_lt_20_count": age_lt_20_count,
+                "age_lt_20_share": _share(age_lt_20_count),
+                "age_lt_30_count": age_lt_30_count,
+                "age_lt_30_share": _share(age_lt_30_count),
+                "age_lt_80_count": age_lt_80_count,
+                "age_lt_80_share": _share(age_lt_80_count),
+                "age_gte_80_count": age_gte_80_count,
+                "age_gte_80_share": _share(age_gte_80_count),
+                "old_support_stand_count": old_support_stand_count,
+                "terminal_vdyp_min": float(terminal.min())
+                if len(terminal.dropna())
+                else np.nan,
+                "terminal_vdyp_p25": float(terminal.quantile(0.25))
+                if len(terminal.dropna())
+                else np.nan,
+                "terminal_vdyp_median": float(terminal.median())
+                if len(terminal.dropna())
+                else np.nan,
+                "terminal_vdyp_p75": float(terminal.quantile(0.75))
+                if len(terminal.dropna())
+                else np.nan,
+                "terminal_vdyp_max": float(terminal.max())
+                if len(terminal.dropna())
+                else np.nan,
+                "low_terminal_stand_count": low_count,
+                "high_terminal_stand_count": high_count,
+                "population_pattern": pattern,
+                "curve_issue_class": issue_class,
+            }
+        )
+
+        if not flagged:
+            continue
+        for _, row in joined.sort_values(
+            ["terminal_vdyp_volume", "forest_cover_id"],
+            kind="stable",
+            na_position="last",
+        ).iterrows():
+            detail_rows.append(
+                {
+                    "au_id": au_id,
+                    "selected_rank": int(selected_row["selected_rank"]),
+                    "forest_cover_id": int(row["forest_cover_id"]),
+                    "shape_area_ha": float(row["shape_area_ha"]),
+                    "site_index": row.get("TCL_1_ESTIMATED_SITE_INDEX"),
+                    "age_2020": row.get("AGE_2020"),
+                    "terminal_vdyp_age": row.get("terminal_vdyp_age"),
+                    "terminal_vdyp_volume": row.get("terminal_vdyp_volume"),
+                }
+            )
+
+    summary_frame = pd.DataFrame(summary_rows)
+    if not summary_frame.empty:
+        summary_frame = summary_frame.sort_values(
+            ["flagged", "terminal_volume", "selected_rank"],
+            ascending=[False, True, True],
+            kind="stable",
+        )
+
+    detail_frame = pd.DataFrame(detail_rows)
+    if not detail_frame.empty:
+        detail_frame = detail_frame.sort_values(
+            ["selected_rank", "terminal_vdyp_volume", "forest_cover_id"],
+            kind="stable",
+            na_position="last",
+        )
+
+    summary_path = output_dir / "bad_curve_audit_summary.csv"
+    detail_path = output_dir / "bad_curve_audit_detail.csv"
+    summary_frame.to_csv(summary_path, index=False)
+    detail_frame.to_csv(detail_path, index=False)
+
+    return MkrfBadCurveAuditResult(
+        output_dir=output_dir,
+        summary_path=summary_path,
+        detail_path=detail_path,
+        flagged_au_count=int(summary_frame["flagged"].astype(bool).sum()),
+        total_selected_au_count=int(len(summary_frame)),
+    )
+
+
+def initialize_mkrf_runtime_package(
+    *,
+    package_root: Path,
+    selected_au_csv: Path,
+    stand_origin_assignment_csv: Path,
+    stand_au_assignment_csv: Path,
+    managed_bootstrap_csv: Path,
+    first_growth_curves_csv: Path,
+    first_growth_diagnostics_csv: Path,
+    managed_curves_csv: Path,
+    managed_run_manifest_json: Path,
+    bad_curve_audit_summary_csv: Path,
+) -> MkrfRuntimePackageInitResult:
+    """Initialize the canonical MKRF runtime-package root and write an init manifest."""
+    package_root = package_root.resolve()
+    readme_path = package_root / "README.md"
+    analysis_dir = package_root / "analysis"
+    analysis_pin_path = analysis_dir / "base.pin"
+    headless_runtime_common_path = analysis_dir / "headless_runtime_common.bsh"
+    xml_dir = package_root / "xml"
+    tracks_dir = package_root / "tracks"
+    targets_dir = package_root / "scripts" / "targets"
+    flow_targets_script_path = targets_dir / "flowtargets.bsh"
+    manifest_path = analysis_dir / "runtime_package_init_manifest.json"
+    curve_status_path = analysis_dir / "runtime_curve_status.csv"
+    analysis_au_runtime_status_path = analysis_dir / "au_runtime_status.csv"
+    analysis_au_curve_refs_path = analysis_dir / "au_curve_refs.csv"
+    runtime_au_remap_audit_path = analysis_dir / "runtime_au_remap_audit.csv"
+    species_share_audit_path = analysis_dir / "runtime_species_share_audit.csv"
+    ct_eligibility_audit_path = analysis_dir / "ct_eligibility_audit.csv"
+    ct_intensity_audit_path = analysis_dir / "ct_intensity_audit.csv"
+    ct_intensity_summary_path = analysis_dir / "ct_intensity_summary.csv"
+    hw_ingrowth_overlay_audit_path = (
+        analysis_dir / "planted_hw_ingrowth_overlay_audit.csv"
+    )
+    hw_ingrowth_overlay_summary_path = (
+        analysis_dir / "planted_hw_ingrowth_overlay_summary.csv"
+    )
+    xml_contract_path = xml_dir / "runtime_curve_contract.xml"
+    xml_curve_bank_path = xml_dir / "runtime_curve_bank.xml"
+    forestmodel_xml_path = xml_dir / "forestmodel.xml"
+    required_dirs = (
+        analysis_dir,
+        xml_dir,
+        tracks_dir,
+        package_root / "spatial",
+        package_root / "scripts",
+        targets_dir,
+        package_root / "targets",
+        package_root / "initial_targets",
+    )
+    for directory in required_dirs:
+        directory.mkdir(parents=True, exist_ok=True)
+
+    selected_au = pd.read_csv(selected_au_csv)
+    stand_origin_assignment = pd.read_csv(stand_origin_assignment_csv)
+    stand_au_assignment = pd.read_csv(stand_au_assignment_csv)
+    managed_bootstrap = pd.read_csv(managed_bootstrap_csv)
+    first_growth_curves = pd.read_csv(first_growth_curves_csv)
+    first_growth_diagnostics = pd.read_csv(first_growth_diagnostics_csv)
+    managed_curves = pd.read_csv(managed_curves_csv)
+    bad_curve_summary = pd.read_csv(bad_curve_audit_summary_csv)
+    managed_manifest = json.loads(managed_run_manifest_json.read_text(encoding="utf-8"))
+
+    normalized_assignment, remap_audit = _normalize_runtime_au_assignments(
+        selected_au_table=selected_au,
+        stand_origin_assignment=stand_origin_assignment,
+        managed_curves=managed_curves,
+        first_growth_diagnostics=first_growth_diagnostics,
+    )
+    remap_audit.to_csv(runtime_au_remap_audit_path, index=False)
+    au_lookup = (
+        normalized_assignment[["forest_cover_id", "au_id"]]
+        .drop_duplicates(subset=["forest_cover_id"], keep="first")
+        .sort_values("forest_cover_id", kind="stable")
+    )
+    forest_cover_ids = au_lookup["forest_cover_id"].astype(int).astype(str).tolist()
+    rebuild_au_ids = au_lookup["au_id"].tolist()
+    au_lookup_expr = _build_lookup_expr(
+        forest_cover_ids,
+        rebuild_au_ids,
+        key_expr="Int(FOREST_COV)",
+    )
+    forest_cover_origin_lookup = (
+        normalized_assignment[["forest_cover_id", "origin_class"]]
+        .drop_duplicates(subset=["forest_cover_id"], keep="first")
+        .assign(
+            forest_cover_id=lambda df: df["forest_cover_id"].astype(int).astype(str),
+            runtime_origin=lambda df: np.where(
+                df["origin_class"].astype(str).eq("fire_origin"),
+                "natural",
+                "treated",
+            ),
+        )
+        .sort_values("forest_cover_id", kind="stable")
+    )
+    origin_lookup_expr = _build_lookup_expr(
+        forest_cover_origin_lookup["forest_cover_id"].tolist(),
+        forest_cover_origin_lookup["runtime_origin"].tolist(),
+        key_expr="Int(FOREST_COV)",
+    )
+
+    selected_au_count = int(selected_au["au_id"].astype(str).nunique())
+    managed_curve_au_count = int(managed_curves["au_id"].astype(str).nunique())
+    flagged_au_count = int(
+        bad_curve_summary["flagged"].fillna(False).astype(bool).sum()
+    )
+
+    first_growth_path_by_au = (
+        first_growth_diagnostics[["au_id", "selected_path"]]
+        .drop_duplicates(subset=["au_id"], keep="last")
+        .assign(
+            au_id=lambda df: df["au_id"].astype(str),
+            selected_path=lambda df: df["selected_path"].astype(str),
+        )
+    )
+    managed_curve_aus = set(managed_curves["au_id"].astype(str).unique())
+    bad_curve_flagged = (
+        bad_curve_summary[["au_id", "flagged"]]
+        .drop_duplicates(subset=["au_id"], keep="last")
+        .assign(
+            au_id=lambda df: df["au_id"].astype(str),
+            flagged=lambda df: df["flagged"].fillna(False).astype(bool),
+        )
+    )
+    runtime_curve_status = (
+        selected_au[["au_id"]]
+        .assign(au_id=lambda df: df["au_id"].astype(str))
+        .merge(first_growth_path_by_au, on="au_id", how="left")
+        .merge(bad_curve_flagged, on="au_id", how="left")
+    )
+    runtime_curve_status["flagged_bad_curve"] = (
+        runtime_curve_status["flagged"].fillna(False).astype(bool)
+    )
+    runtime_curve_status = runtime_curve_status.drop(columns=["flagged"])
+    runtime_curve_status["has_first_growth_curve"] = runtime_curve_status[
+        "selected_path"
+    ].notna() & (
+        ~runtime_curve_status["selected_path"].eq("insufficient_source_stands")
+    )
+    runtime_curve_status["has_managed_curve"] = runtime_curve_status["au_id"].isin(
+        managed_curve_aus
+    )
+    runtime_curve_status["runtime_curve_mode"] = np.where(
+        runtime_curve_status["has_first_growth_curve"]
+        & runtime_curve_status["has_managed_curve"],
+        "first_growth_and_managed",
+        np.where(
+            (~runtime_curve_status["has_first_growth_curve"])
+            & runtime_curve_status["has_managed_curve"]
+            & runtime_curve_status["selected_path"]
+            .fillna("")
+            .eq("insufficient_source_stands"),
+            "managed_only",
+            "incomplete",
+        ),
+    )
+    runtime_curve_status["runtime_curve_note"] = np.where(
+        runtime_curve_status["runtime_curve_mode"].eq("managed_only"),
+        "insufficient_source_stands_managed_only",
+        "",
+    )
+    runtime_curve_status = runtime_curve_status.rename(
+        columns={"selected_path": "first_growth_selected_path"}
+    ).sort_values("au_id", kind="stable")
+    first_growth_curve_au_count = int(
+        runtime_curve_status["has_first_growth_curve"].fillna(False).astype(bool).sum()
+    )
+    first_growth_missing_au_count = int(
+        (
+            ~runtime_curve_status["has_first_growth_curve"].fillna(False).astype(bool)
+        ).sum()
+    )
+    runtime_curve_status.to_csv(curve_status_path, index=False)
+    tracks_status = selected_au.assign(au_id=lambda df: df["au_id"].astype(str)).merge(
+        runtime_curve_status[
+            [
+                "au_id",
+                "first_growth_selected_path",
+                "has_first_growth_curve",
+                "has_managed_curve",
+                "runtime_curve_mode",
+                "runtime_curve_note",
+                "flagged_bad_curve",
+            ]
+        ],
+        on="au_id",
+        how="left",
+    )
+    tracks_sort_columns = ["au_id"]
+    if "selected_rank" in tracks_status.columns:
+        tracks_sort_columns = ["selected_rank", "au_id"]
+    tracks_status = tracks_status.sort_values(tracks_sort_columns, kind="stable")
+    tracks_status.to_csv(analysis_au_runtime_status_path, index=False)
+    curve_ref_rows: list[dict[str, object]] = []
+    for row in runtime_curve_status.sort_values("au_id", kind="stable").itertuples(
+        index=False
+    ):
+        au_token = str(row.au_id).upper().replace("-", "_")
+        curve_ref_rows.append(
+            {
+                "au_id": str(row.au_id),
+                "runtime_curve_mode": str(row.runtime_curve_mode),
+                "first_growth_selected_path": (
+                    str(row.first_growth_selected_path)
+                    if pd.notna(row.first_growth_selected_path)
+                    else ""
+                ),
+                "has_first_growth_curve": bool(row.has_first_growth_curve),
+                "has_managed_curve": bool(row.has_managed_curve),
+                "first_growth_curve_id": (
+                    f"FG_{au_token}" if bool(row.has_first_growth_curve) else ""
+                ),
+                "managed_curve_id": f"MG_{au_token}"
+                if bool(row.has_managed_curve)
+                else "",
+                "flagged_bad_curve": bool(row.flagged_bad_curve),
+                "runtime_curve_note": (
+                    str(row.runtime_curve_note)
+                    if pd.notna(row.runtime_curve_note)
+                    and str(row.runtime_curve_note).strip()
+                    else ""
+                ),
+            }
+        )
+    pd.DataFrame(curve_ref_rows).to_csv(analysis_au_curve_refs_path, index=False)
+    managed_curve_lookup_rows = [
+        row for row in curve_ref_rows if row["managed_curve_id"]
+    ]
+    managed_curve_au_ids = [str(row["au_id"]) for row in managed_curve_lookup_rows]
+    managed_curve_ids = [
+        str(row["managed_curve_id"]) for row in managed_curve_lookup_rows
+    ]
+    first_growth_curve_lookup_rows = [
+        row for row in curve_ref_rows if row["first_growth_curve_id"]
+    ]
+    first_growth_curve_au_ids = [
+        str(row["au_id"]) for row in first_growth_curve_lookup_rows
+    ]
+    first_growth_curve_ids = [
+        str(row["first_growth_curve_id"]) for row in first_growth_curve_lookup_rows
+    ]
+    ct_bucket_specs = _mkrf_ct_bucket_specs()
+    runtime_base_au_expr = (
+        f"if(startswith(au,'thn'),substring(au,{len(_mkrf_ct_bucket_prefix(40))}),au)"
+    )
+    runtime_state_expr = "if(startswith(au,'thn'),'THN',statecode)"
+    managed_curve_lookup_expr = _build_lookup_expr(
+        managed_curve_au_ids,
+        managed_curve_ids,
+        key_expr=runtime_base_au_expr,
+    )
+    first_growth_curve_lookup_expr = _build_lookup_expr(
+        first_growth_curve_au_ids,
+        first_growth_curve_ids,
+        key_expr=runtime_base_au_expr,
+    )
+    forest_cover_fg_lookup = (
+        normalized_assignment[["forest_cover_id", "au_id"]]
+        .drop_duplicates(subset=["forest_cover_id"], keep="first")
+        .merge(
+            runtime_curve_status[["au_id", "has_first_growth_curve"]],
+            on="au_id",
+            how="left",
+        )
+        .assign(
+            forest_cover_id=lambda df: df["forest_cover_id"].astype(int).astype(str),
+            has_first_growth_curve=lambda df: np.where(
+                df["has_first_growth_curve"].fillna(False).astype(bool), "Y", "N"
+            ),
+        )
+        .sort_values("forest_cover_id", kind="stable")
+    )
+    has_first_growth_lookup_expr = _build_lookup_expr(
+        forest_cover_fg_lookup["forest_cover_id"].tolist(),
+        forest_cover_fg_lookup["has_first_growth_curve"].tolist(),
+        key_expr="Int(FOREST_COV)",
+    )
+    managed_species_shares = _build_managed_species_share_table(managed_bootstrap)
+    managed_species_shares = managed_species_shares.assign(
+        au_id=lambda df: df["au_id"].astype(str)
+    ).sort_values("au_id", kind="stable")
+    ct_eligibility_species_shares = _build_managed_species_share_table(
+        managed_bootstrap,
+        species_prefix=(
+            "base_managed"
+            if "base_managed_species_1" in managed_bootstrap.columns
+            else "managed"
+        ),
+    )
+    ct_eligibility_species_shares = ct_eligibility_species_shares.assign(
+        au_id=lambda df: df["au_id"].astype(str)
+    ).sort_values("au_id", kind="stable")
+    unmanaged_share_assignment = stand_au_assignment.merge(
+        normalized_assignment[["forest_cover_id", "au_id"]]
+        .drop_duplicates(subset=["forest_cover_id"], keep="first")
+        .rename(columns={"au_id": "runtime_au_id"}),
+        on="forest_cover_id",
+        how="left",
+    )
+    unmanaged_share_assignment["au_id"] = (
+        unmanaged_share_assignment["runtime_au_id"]
+        .fillna(unmanaged_share_assignment["au_id"])
+        .astype(str)
+        .str.strip()
+    )
+    unmanaged_share_assignment = unmanaged_share_assignment.drop(
+        columns=["runtime_au_id"]
+    )
+    unmanaged_species_shares = _build_unmanaged_species_share_table(
+        unmanaged_share_assignment,
+        selected_au_table=selected_au,
+    )
+    unmanaged_species_shares = unmanaged_species_shares.assign(
+        au_id=lambda df: df["au_id"].astype(str)
+    ).sort_values("au_id", kind="stable")
+    managed_share_label_map = {
+        "share_ba": "Ba",
+        "share_cw": "Cw",
+        "share_dec": "Dec",
+        "share_dr": "Dr",
+        "share_fd": "Fd",
+        "share_hw": "Hw",
+        "share_oth": "Oth",
+        "share_yc": "Yc",
+    }
+    managed_share_lookup_exprs: dict[str, str] = {}
+    managed_share_keys = managed_species_shares["au_id"].tolist()
+    for share_column in managed_share_label_map:
+        managed_share_values = [
+            str(float(value))
+            for value in managed_species_shares[share_column].fillna(0.0).tolist()
+        ]
+        lookup_expr = _build_lookup_expr(
+            managed_share_keys,
+            managed_share_values,
+            key_expr=runtime_base_au_expr,
+        )
+        managed_share_lookup_exprs[share_column] = f"Number({lookup_expr})/100"
+    ct_eligibility_species_shares = ct_eligibility_species_shares.assign(
+        share_cw_fd=lambda df: (
+            pd.to_numeric(df["share_cw"], errors="coerce").fillna(0.0)
+            + pd.to_numeric(df["share_fd"], errors="coerce").fillna(0.0)
+        )
+    )
+    ct_eligibility_cw_fd_values = [
+        str(float(value))
+        for value in ct_eligibility_species_shares["share_cw_fd"].fillna(0.0).tolist()
+    ]
+    ct_eligibility_cw_fd_lookup_expr = (
+        "Number("
+        + _build_lookup_expr(
+            ct_eligibility_species_shares["au_id"].tolist(),
+            ct_eligibility_cw_fd_values,
+            key_expr=runtime_base_au_expr,
+        )
+        + ")/100"
+    )
+    unmanaged_share_lookup_exprs: dict[str, str] = {}
+    unmanaged_share_keys = unmanaged_species_shares["au_id"].tolist()
+    for share_column in managed_share_label_map:
+        unmanaged_share_values = [
+            str(float(value))
+            for value in unmanaged_species_shares[share_column].fillna(0.0).tolist()
+        ]
+        lookup_expr = _build_lookup_expr(
+            unmanaged_share_keys,
+            unmanaged_share_values,
+            key_expr=runtime_base_au_expr,
+        )
+        unmanaged_share_lookup_exprs[share_column] = f"Number({lookup_expr})/100"
+    species_share_audit = _build_species_share_audit_table(
+        managed_species_shares=managed_species_shares,
+        unmanaged_species_shares=unmanaged_species_shares,
+    )
+    species_share_audit.to_csv(species_share_audit_path, index=False)
+    ct_eligibility_audit = _build_ct_eligibility_audit_table(
+        selected_au_table=selected_au,
+        ct_eligibility_species_shares=ct_eligibility_species_shares,
+    )
+    ct_eligibility_audit.to_csv(ct_eligibility_audit_path, index=False)
+    ct_intensity_audit, ct_intensity_summary = _build_ct_intensity_audit_tables(
+        ct_eligibility_audit=ct_eligibility_audit,
+        treated_species_shares=managed_species_shares,
+        ct_bucket_specs=ct_bucket_specs,
+    )
+    ct_intensity_audit.to_csv(ct_intensity_audit_path, index=False)
+    ct_intensity_summary.to_csv(ct_intensity_summary_path, index=False)
+    hw_ingrowth_overlay_audit, hw_ingrowth_overlay_summary = (
+        _build_hw_ingrowth_overlay_audit_tables(managed_bootstrap=managed_bootstrap)
+    )
+    hw_ingrowth_overlay_audit.to_csv(hw_ingrowth_overlay_audit_path, index=False)
+    hw_ingrowth_overlay_summary.to_csv(hw_ingrowth_overlay_summary_path, index=False)
+    origin_share_lookup_exprs = {
+        share_column: (
+            f"if(origin eq 'natural',{unmanaged_share_lookup_exprs[share_column]},"
+            f"{managed_share_lookup_exprs[share_column]})"
+        )
+        for share_column in managed_share_label_map
+    }
+    first_growth_by_au = {
+        str(au_id): group.sort_values("age", kind="stable")
+        for au_id, group in first_growth_curves.groupby("au_id", sort=True)
+    }
+    managed_by_au = {
+        str(au_id): group.sort_values("age", kind="stable")
+        for au_id, group in managed_curves.groupby("au_id", sort=True)
+    }
+
+    def _curve_group_value_at_age(curve_group: pd.DataFrame, age: int) -> float:
+        if curve_group.empty:
+            return 0.0
+        x_vals = curve_group["age"].astype(float).to_numpy()
+        y_vals = curve_group["volume"].astype(float).to_numpy()
+        return float(np.interp(float(age), x_vals, y_vals))
+
+    bucketed_thn_keys: list[str] = []
+    natural_bucketed_thn_curve_ids: list[str] = []
+    treated_bucketed_thn_curve_ids: list[str] = []
+    ct_product_keys: list[str] = []
+    natural_ct_product_curve_ids: list[str] = []
+    treated_ct_product_curve_ids: list[str] = []
+    for row in runtime_curve_status.sort_values("au_id", kind="stable").itertuples(
+        index=False
+    ):
+        au_id = str(row.au_id)
+        managed_group = managed_by_au.get(au_id)
+        if managed_group is None or managed_group.empty:
+            continue
+        natural_group = first_growth_by_au.get(au_id, managed_group)
+        au_token = au_id.upper().replace("-", "_")
+        for bucket_spec in ct_bucket_specs:
+            anchor_age = int(bucket_spec["anchor_age"])
+            bucket_prefix = str(bucket_spec["prefix"])
+            bucket_label = str(bucket_spec["label"])
+            natural_gap = round(
+                _curve_group_value_at_age(natural_group, anchor_age)
+                * _MKRF_CT_TARGET_BA_REMOVAL_FRACTION,
+                6,
+            )
+            treated_gap = round(
+                _curve_group_value_at_age(managed_group, anchor_age)
+                * _MKRF_CT_TARGET_BA_REMOVAL_FRACTION,
+                6,
+            )
+            natural_residual_curve_id = f"THN{anchor_age:03d}_FG_{au_token}"
+            treated_residual_curve_id = f"THN{anchor_age:03d}_MG_{au_token}"
+            natural_extraction_curve_id = f"CT{anchor_age:03d}_FG_{au_token}"
+            treated_extraction_curve_id = f"CT{anchor_age:03d}_MG_{au_token}"
+            bucketed_thn_keys.append(f"{bucket_prefix}{au_id}")
+            natural_bucketed_thn_curve_ids.append(natural_residual_curve_id)
+            treated_bucketed_thn_curve_ids.append(treated_residual_curve_id)
+            ct_product_keys.append(f"{bucket_label}|{au_id}")
+            natural_ct_product_curve_ids.append(natural_extraction_curve_id)
+            treated_ct_product_curve_ids.append(treated_extraction_curve_id)
+    origin_curve_lookup_expr = (
+        "if(origin eq 'natural' and hasnatcurve eq 'Y',"
+        f"curveId({first_growth_curve_lookup_expr}),"
+        f"curveId({managed_curve_lookup_expr}))"
+    )
+    natural_bucketed_thn_curve_lookup_expr = _build_lookup_expr(
+        bucketed_thn_keys,
+        natural_bucketed_thn_curve_ids,
+        key_expr="au",
+    )
+    treated_bucketed_thn_curve_lookup_expr = _build_lookup_expr(
+        bucketed_thn_keys,
+        treated_bucketed_thn_curve_ids,
+        key_expr="au",
+    )
+    ct_product_key_expr = f"treatment+'|'+{runtime_base_au_expr}"
+    natural_ct_product_curve_lookup_expr = _build_lookup_expr(
+        ct_product_keys,
+        natural_ct_product_curve_ids,
+        key_expr=ct_product_key_expr,
+    )
+    treated_ct_product_curve_lookup_expr = _build_lookup_expr(
+        ct_product_keys,
+        treated_ct_product_curve_ids,
+        key_expr=ct_product_key_expr,
+    )
+    standing_curve_expr = (
+        f"if(startswith(au,'thn'),"
+        "curveId("
+        f"if(origin eq 'natural',{natural_bucketed_thn_curve_lookup_expr},"
+        f"{treated_bucketed_thn_curve_lookup_expr})"
+        "),"
+        f"{origin_curve_lookup_expr})"
+    )
+    product_curve_expr = (
+        "if(startswith(treatment,'CT'),"
+        "curveId("
+        f"if(origin eq 'natural',{natural_ct_product_curve_lookup_expr},"
+        f"{treated_ct_product_curve_lookup_expr})"
+        "),"
+        f"{standing_curve_expr})"
+    )
+    for obsolete_path in (
+        tracks_dir / "au_runtime_status.csv",
+        tracks_dir / "au_curve_refs.csv",
+    ):
+        if obsolete_path.exists():
+            obsolete_path.unlink()
+
+    root = et.Element(
+        "mkrfRuntimeCurveContract",
+        {
+            "schemaVersion": "1",
+            "runtimeGenerationStatus": "initialized_only",
+        },
+    )
+    counts_node = et.SubElement(root, "counts")
+    counts_node.set("selectedAuCount", str(selected_au_count))
+    counts_node.set("firstGrowthCurveAuCount", str(first_growth_curve_au_count))
+    counts_node.set("firstGrowthMissingAuCount", str(first_growth_missing_au_count))
+    counts_node.set("managedCurveAuCount", str(managed_curve_au_count))
+    counts_node.set(
+        "managedOnlyRuntimeAuCount",
+        str(int(runtime_curve_status["runtime_curve_mode"].eq("managed_only").sum())),
+    )
+    policy_node = et.SubElement(root, "policy")
+    policy_node.set("firstGrowthCurveFamily", "smoothed_bin_pchip")
+    policy_node.set("firstGrowthBorrowingAllowed", "false")
+    policy_node.set("managedOnlyRuntimeUnitsAllowed", "true")
+    policy_node.set("insufficientSupportFallbackGeneration", "forbidden")
+    policy_node.set("insufficientSupportBorrowing", "forbidden")
+    source_node = et.SubElement(root, "sourceContracts")
+    for tag, path in (
+        ("selectedAuCsv", selected_au_csv),
+        ("standOriginAssignmentCsv", stand_origin_assignment_csv),
+        ("standAuAssignmentCsv", stand_au_assignment_csv),
+        ("managedBootstrapCsv", managed_bootstrap_csv),
+        ("firstGrowthCurvesCsv", first_growth_curves_csv),
+        ("firstGrowthDiagnosticsCsv", first_growth_diagnostics_csv),
+        ("managedCurvesCsv", managed_curves_csv),
+        ("managedRunManifestJson", managed_run_manifest_json),
+        ("badCurveAuditSummaryCsv", bad_curve_audit_summary_csv),
+        ("runtimeCurveStatusCsv", curve_status_path),
+        ("speciesShareAuditCsv", species_share_audit_path),
+    ):
+        child = et.SubElement(source_node, tag)
+        child.text = _manifest_path_value(path)
+    aus_node = et.SubElement(root, "analysisUnits")
+    for row in runtime_curve_status.itertuples(index=False):
+        au_node = et.SubElement(aus_node, "au")
+        au_node.set("id", str(row.au_id))
+        au_node.set("runtimeCurveMode", str(row.runtime_curve_mode))
+        au_node.set(
+            "hasManagedCurve", "true" if bool(row.has_managed_curve) else "false"
+        )
+        au_node.set(
+            "hasFirstGrowthCurve",
+            "true" if bool(row.has_first_growth_curve) else "false",
+        )
+        au_node.set(
+            "flaggedBadCurve", "true" if bool(row.flagged_bad_curve) else "false"
+        )
+        if pd.notna(row.first_growth_selected_path):
+            au_node.set("firstGrowthSelectedPath", str(row.first_growth_selected_path))
+        if pd.notna(row.runtime_curve_note) and str(row.runtime_curve_note).strip():
+            au_node.set("note", str(row.runtime_curve_note))
+    et.ElementTree(root).write(
+        xml_contract_path, encoding="utf-8", xml_declaration=True
+    )
+
+    curve_bank_root = et.Element(
+        "mkrfRuntimeCurveBank",
+        {
+            "schemaVersion": "1",
+            "curveFamily": "au_wise_runtime_curve_bank",
+        },
+    )
+    for row in runtime_curve_status.itertuples(index=False):
+        au_bank_node = et.SubElement(
+            curve_bank_root,
+            "analysisUnit",
+            {
+                "id": str(row.au_id),
+                "runtimeCurveMode": str(row.runtime_curve_mode),
+            },
+        )
+        if bool(row.has_first_growth_curve):
+            fg_group = first_growth_by_au.get(str(row.au_id))
+            if fg_group is not None and not fg_group.empty:
+                fg_node = et.SubElement(
+                    au_bank_node,
+                    "firstGrowthCurve",
+                    {
+                        "selectedPath": str(row.first_growth_selected_path),
+                    },
+                )
+                for curve_row in fg_group.itertuples(index=False):
+                    point_node = et.SubElement(fg_node, "point")
+                    point_node.set("age", str(float(curve_row.age)))
+                    point_node.set("volume", str(float(curve_row.volume)))
+        if bool(row.has_managed_curve):
+            managed_group = managed_by_au.get(str(row.au_id))
+            if managed_group is not None and not managed_group.empty:
+                managed_node = et.SubElement(au_bank_node, "managedCurve")
+                for curve_row in managed_group.itertuples(index=False):
+                    point_node = et.SubElement(managed_node, "point")
+                    point_node.set("age", str(float(curve_row.age)))
+                    point_node.set("volume", str(float(curve_row.volume)))
+    et.ElementTree(curve_bank_root).write(
+        xml_curve_bank_path, encoding="utf-8", xml_declaration=True
+    )
+
+    forestmodel_root = et.Element(
+        "ForestModel",
+        {
+            "description": "MKRF canonical rebuild",
+            "horizon": "300",
+            "year": "2020",
+            "match": "multi",
+        },
+    )
+    forestmodel_root.append(
+        et.Comment(
+            "Generated from accepted MKRF AU-wise runtime curve surfaces. Not yet runnable."
+        )
+    )
+    forestmodel_root.append(
+        et.Comment(
+            f"Curve contract: {xml_contract_path.name}; curve bank: {xml_curve_bank_path.name}"
+        )
+    )
+    curve_node = et.SubElement(forestmodel_root, "curve", {"id": "unity"})
+    et.SubElement(curve_node, "point", {"x": "0", "y": "1"})
+    le10_curve = et.SubElement(forestmodel_root, "curve", {"id": "le10"})
+    et.SubElement(le10_curve, "point", {"x": "10", "y": "1"})
+    et.SubElement(le10_curve, "point", {"x": "11", "y": "0"})
+    for row in runtime_curve_status.itertuples(index=False):
+        au_token = str(row.au_id).upper().replace("-", "_")
+        if bool(row.has_first_growth_curve):
+            fg_group = first_growth_by_au.get(str(row.au_id))
+            if fg_group is not None and not fg_group.empty:
+                fg_curve = et.SubElement(
+                    forestmodel_root, "curve", {"id": f"FG_{au_token}"}
+                )
+                for curve_row in fg_group.itertuples(index=False):
+                    et.SubElement(
+                        fg_curve,
+                        "point",
+                        {
+                            "x": str(float(curve_row.age)),
+                            "y": str(float(curve_row.volume)),
+                        },
+                    )
+        if bool(row.has_managed_curve):
+            managed_group = managed_by_au.get(str(row.au_id))
+            if managed_group is not None and not managed_group.empty:
+                mg_curve = et.SubElement(
+                    forestmodel_root, "curve", {"id": f"MG_{au_token}"}
+                )
+                for curve_row in managed_group.itertuples(index=False):
+                    et.SubElement(
+                        mg_curve,
+                        "point",
+                        {
+                            "x": str(float(curve_row.age)),
+                            "y": str(float(curve_row.volume)),
+                        },
+                    )
+        managed_group = managed_by_au.get(str(row.au_id))
+        if managed_group is None or managed_group.empty:
+            continue
+        natural_group = first_growth_by_au.get(str(row.au_id), managed_group)
+        for bucket_spec in ct_bucket_specs:
+            anchor_age = int(bucket_spec["anchor_age"])
+            natural_gap = round(
+                _curve_group_value_at_age(natural_group, anchor_age)
+                * _MKRF_CT_TARGET_BA_REMOVAL_FRACTION,
+                6,
+            )
+            treated_gap = round(
+                _curve_group_value_at_age(managed_group, anchor_age)
+                * _MKRF_CT_TARGET_BA_REMOVAL_FRACTION,
+                6,
+            )
+            natural_residual_curve = et.SubElement(
+                forestmodel_root,
+                "curve",
+                {"id": f"THN{anchor_age:03d}_FG_{au_token}"},
+            )
+            treated_residual_curve = et.SubElement(
+                forestmodel_root,
+                "curve",
+                {"id": f"THN{anchor_age:03d}_MG_{au_token}"},
+            )
+            natural_extraction_curve = et.SubElement(
+                forestmodel_root,
+                "curve",
+                {"id": f"CT{anchor_age:03d}_FG_{au_token}"},
+            )
+            treated_extraction_curve = et.SubElement(
+                forestmodel_root,
+                "curve",
+                {"id": f"CT{anchor_age:03d}_MG_{au_token}"},
+            )
+            age_values = sorted(
+                {
+                    float(point.age)
+                    for point in natural_group.itertuples(index=False)
+                    if np.isfinite(float(point.age))
+                }
+                | {
+                    float(point.age)
+                    for point in managed_group.itertuples(index=False)
+                    if np.isfinite(float(point.age))
+                }
+            )
+            if not age_values:
+                age_values = [0.0, 100.0]
+            for age_value in age_values:
+                natural_volume = _curve_group_value_at_age(
+                    natural_group, int(age_value)
+                )
+                treated_volume = _curve_group_value_at_age(
+                    managed_group, int(age_value)
+                )
+                et.SubElement(
+                    natural_residual_curve,
+                    "point",
+                    {
+                        "x": str(float(age_value)),
+                        "y": str(max(0.0, natural_volume - natural_gap)),
+                    },
+                )
+                et.SubElement(
+                    treated_residual_curve,
+                    "point",
+                    {
+                        "x": str(float(age_value)),
+                        "y": str(max(0.0, treated_volume - treated_gap)),
+                    },
+                )
+                et.SubElement(
+                    natural_extraction_curve,
+                    "point",
+                    {"x": str(float(age_value)), "y": str(max(0.0, natural_gap))},
+                )
+                et.SubElement(
+                    treated_extraction_curve,
+                    "point",
+                    {"x": str(float(age_value)), "y": str(max(0.0, treated_gap))},
+                )
+    define_specs = (
+        {"field": "status", "column": "CONTCLAS"},
+        {"field": "origin", "column": origin_lookup_expr},
+        {
+            "field": "statecode",
+            "column": f"if({origin_lookup_expr} eq 'natural','EN','EM')",
+        },
+        {"field": "au", "column": au_lookup_expr},
+        {"field": "auf", "column": au_lookup_expr},
+        {"field": "oper", "column": "Operabilit"},
+        {"field": "ct", "column": "CT_eligib"},
+        {"field": "aux", "column": "Int(FOREST_COV)"},
+        {"field": "hasnatcurve", "column": has_first_growth_lookup_expr},
+        {"field": "treatment"},
+        {"field": "managed", "constant": "'C'"},
+        {"field": "unmanaged", "constant": "'N'"},
+        {"field": "operable", "constant": "'Operable'"},
+        {"field": "lowoper", "constant": "'Low Operability'"},
+        {"field": "frd", "constant": "0.027"},
+    )
+    for define_spec in define_specs:
+        et.SubElement(forestmodel_root, "define", define_spec)
+    et.SubElement(
+        forestmodel_root,
+        "input",
+        {
+            "block": "Int(RES_KEY)",
+            "area": "Shape_Area/10000",
+            "age": "Int(AGE_2020)",
+            "exclude": "CONTCLAS eq 'X'",
+        },
+    )
+    et.SubElement(
+        forestmodel_root,
+        "output",
+        {
+            "messages": "messages.csv",
+            "blocks": "blocks.csv",
+            "features": "features.csv",
+            "products": "products.csv",
+            "treatments": "treatments.csv",
+            "curves": "curves.csv",
+            "tracknames": "tracknames.csv",
+        },
+    )
+    forestmodel_root.append(
+        et.Comment(
+            "Runtime references: "
+            f"{xml_contract_path.name}, {xml_curve_bank_path.name}, {curve_status_path.name}"
+        )
+    )
+    managed_operable_select = et.SubElement(
+        forestmodel_root,
+        "select",
+        {"statement": "status in managed and oper in operable"},
+    )
+    managed_operable_retention = et.SubElement(
+        managed_operable_select, "retention", {"factor": "0.1"}
+    )
+    et.SubElement(
+        managed_operable_retention,
+        "assign",
+        {"field": "status", "value": "unmanaged"},
+    )
+    managed_operable_features = et.SubElement(managed_operable_retention, "features")
+    managed_operable_attr = et.SubElement(
+        managed_operable_features,
+        "attribute",
+        {"label": "feature.area.retention.total"},
+    )
+    et.SubElement(managed_operable_attr, "curve", {"idref": "unity"})
+
+    managed_lowoper_select = et.SubElement(
+        forestmodel_root,
+        "select",
+        {"statement": "status in managed and oper in lowoper"},
+    )
+    managed_lowoper_retention = et.SubElement(
+        managed_lowoper_select, "retention", {"factor": "0.2"}
+    )
+    et.SubElement(
+        managed_lowoper_retention,
+        "assign",
+        {"field": "status", "value": "unmanaged"},
+    )
+    managed_lowoper_features = et.SubElement(managed_lowoper_retention, "features")
+    managed_lowoper_attr = et.SubElement(
+        managed_lowoper_features,
+        "attribute",
+        {"label": "feature.area.retention.total"},
+    )
+    et.SubElement(managed_lowoper_attr, "curve", {"idref": "unity"})
+
+    unmanaged_select = et.SubElement(
+        forestmodel_root,
+        "select",
+        {"statement": "status in unmanaged"},
+    )
+    et.SubElement(unmanaged_select, "track")
+
+    succession_select = et.SubElement(forestmodel_root, "select")
+    et.SubElement(succession_select, "succession", {"breakup": "999", "renew": "0"})
+
+    managed_cc_select = et.SubElement(
+        forestmodel_root,
+        "select",
+        {"statement": "status in managed"},
+    )
+    managed_cc_track = et.SubElement(managed_cc_select, "track")
+    managed_cc_treatment = et.SubElement(
+        managed_cc_track,
+        "treatment",
+        {"label": "CC", "minage": "if(oper in operable, 60, 150)"},
+    )
+    managed_cc_produce = et.SubElement(managed_cc_treatment, "produce")
+    et.SubElement(
+        managed_cc_produce,
+        "assign",
+        {"field": "treatment", "value": "'CC'"},
+    )
+    managed_cc_transition = et.SubElement(managed_cc_treatment, "transition")
+    et.SubElement(
+        managed_cc_transition,
+        "assign",
+        {"field": "au", "value": "auf"},
+    )
+    et.SubElement(
+        managed_cc_transition,
+        "assign",
+        {"field": "origin", "value": "'treated'"},
+    )
+    et.SubElement(
+        managed_cc_transition,
+        "assign",
+        {"field": "statecode", "value": "'FM'"},
+    )
+
+    ct_select = et.SubElement(
+        forestmodel_root,
+        "select",
+        {
+            "statement": (
+                "status in managed and oper in operable and ct eq 'Y' "
+                "and not startswith(au,'thn') "
+                f"and {ct_eligibility_cw_fd_lookup_expr} ge "
+                f"{_MKRF_CT_MIN_CW_FD_SHARE_PCT / 100.0}"
+            )
+        },
+    )
+    ct_track = et.SubElement(ct_select, "track")
+    for bucket_spec in ct_bucket_specs:
+        ct_treatment = et.SubElement(
+            ct_track,
+            "treatment",
+            {
+                "label": str(bucket_spec["label"]),
+                "minage": str(int(bucket_spec["min_age"])),
+                "maxage": str(int(bucket_spec["max_age"])),
+                "retain": "20",
+            },
+        )
+        ct_produce = et.SubElement(ct_treatment, "produce")
+        et.SubElement(
+            ct_produce,
+            "assign",
+            {"field": "treatment", "value": f"'{str(bucket_spec['label'])}'"},
+        )
+        ct_transition = et.SubElement(ct_treatment, "transition")
+        et.SubElement(
+            ct_transition,
+            "assign",
+            {"field": "au", "value": f"'{str(bucket_spec['prefix'])}'+au"},
+        )
+    area_features_select = et.SubElement(forestmodel_root, "select")
+    area_features = et.SubElement(area_features_select, "features")
+    area_total_attr = et.SubElement(
+        area_features,
+        "attribute",
+        {"label": "%f.area.%m.total"},
+    )
+    et.SubElement(area_total_attr, "curve", {"idref": "unity"})
+    area_state_attr = et.SubElement(
+        area_features,
+        "attribute",
+        {"label": f"'%f.area.%m.state.'+{runtime_state_expr}"},
+    )
+    et.SubElement(area_state_attr, "curve", {"idref": "unity"})
+    area_seral_select = et.SubElement(
+        forestmodel_root,
+        "select",
+        {"statement": "status ne 'X'"},
+    )
+    area_seral_features = et.SubElement(area_seral_select, "features")
+    area_seral_attr = et.SubElement(
+        area_seral_features,
+        "attribute",
+        {"label": "%f.area.%m.seral.le10"},
+    )
+    et.SubElement(area_seral_attr, "curve", {"idref": "le10"})
+    managed_yield_select = et.SubElement(
+        forestmodel_root,
+        "select",
+        {"statement": "status in managed"},
+    )
+    managed_yield_features = et.SubElement(managed_yield_select, "features")
+    managed_yield_total = et.SubElement(
+        managed_yield_features,
+        "attribute",
+        {"label": "%f.yield.%m.total"},
+    )
+    et.SubElement(
+        managed_yield_total,
+        "expression",
+        {
+            "statement": standing_curve_expr,
+            "by": "1",
+            "ignoreMissingAttributes": "false",
+        },
+    )
+    managed_yield_state = et.SubElement(
+        managed_yield_features,
+        "attribute",
+        {"label": f"'%f.yield.%m.state.'+{runtime_state_expr}"},
+    )
+    et.SubElement(
+        managed_yield_state,
+        "expression",
+        {
+            "statement": standing_curve_expr,
+            "by": "1",
+            "ignoreMissingAttributes": "false",
+        },
+    )
+    managed_yield_merch_select = et.SubElement(
+        forestmodel_root,
+        "select",
+        {"statement": "status in managed"},
+    )
+    managed_yield_merch_features = et.SubElement(managed_yield_merch_select, "features")
+    managed_yield_merch_attr = et.SubElement(
+        managed_yield_merch_features,
+        "attribute",
+        {"label": "%f.yield.%m.merch.total"},
+    )
+    et.SubElement(
+        managed_yield_merch_attr,
+        "expression",
+        {
+            "statement": "operable(attribute('feature.yield.%m.total'))",
+            "by": "1",
+            "ignoreMissingAttributes": "false",
+        },
+    )
+    managed_indsp_select = et.SubElement(
+        forestmodel_root,
+        "select",
+        {"statement": "status in managed"},
+    )
+    managed_indsp_features = et.SubElement(managed_indsp_select, "features")
+    for share_column, species_label in managed_share_label_map.items():
+        managed_indsp_attr = et.SubElement(
+            managed_indsp_features,
+            "attribute",
+            {"label": f"%f.yield.%m.indsp.{species_label}"},
+        )
+        et.SubElement(
+            managed_indsp_attr,
+            "expression",
+            {
+                "statement": (
+                    f"{standing_curve_expr}*({origin_share_lookup_exprs[share_column]})"
+                ),
+                "by": "1",
+                "ignoreMissingAttributes": "false",
+            },
+        )
+    unmanaged_yield_select = et.SubElement(
+        forestmodel_root,
+        "select",
+        {"statement": "status in unmanaged"},
+    )
+    unmanaged_yield_features = et.SubElement(unmanaged_yield_select, "features")
+    unmanaged_yield_total = et.SubElement(
+        unmanaged_yield_features,
+        "attribute",
+        {"label": "%f.yield.%m.total"},
+    )
+    et.SubElement(
+        unmanaged_yield_total,
+        "expression",
+        {
+            "statement": standing_curve_expr,
+            "by": "1",
+            "ignoreMissingAttributes": "false",
+        },
+    )
+    unmanaged_yield_state = et.SubElement(
+        unmanaged_yield_features,
+        "attribute",
+        {"label": f"'%f.yield.%m.state.'+{runtime_state_expr}"},
+    )
+    et.SubElement(
+        unmanaged_yield_state,
+        "expression",
+        {
+            "statement": standing_curve_expr,
+            "by": "1",
+            "ignoreMissingAttributes": "false",
+        },
+    )
+    for share_column, species_label in managed_share_label_map.items():
+        unmanaged_yield_indsp = et.SubElement(
+            unmanaged_yield_features,
+            "attribute",
+            {"label": f"%f.yield.%m.indsp.{species_label}"},
+        )
+        et.SubElement(
+            unmanaged_yield_indsp,
+            "expression",
+            {
+                "statement": (
+                    f"{standing_curve_expr}*({origin_share_lookup_exprs[share_column]})"
+                ),
+                "by": "1",
+                "ignoreMissingAttributes": "false",
+            },
+        )
+    products_select = et.SubElement(
+        forestmodel_root,
+        "select",
+        {"statement": ""},
+    )
+    products_node = et.SubElement(products_select, "products")
+    product_area_total = et.SubElement(
+        products_node,
+        "attribute",
+        {"label": "product.area.managed.total"},
+    )
+    et.SubElement(product_area_total, "curve", {"idref": "unity"})
+    product_area_state = et.SubElement(
+        products_node,
+        "attribute",
+        {"label": f"'product.area.managed.state.'+{runtime_state_expr}"},
+    )
+    et.SubElement(product_area_state, "curve", {"idref": "unity"})
+    product_area_treat = et.SubElement(
+        products_node,
+        "attribute",
+        {"label": "'product.area.managed.treat.'+treatment"},
+    )
+    et.SubElement(product_area_treat, "curve", {"idref": "unity"})
+    product_yield_total = et.SubElement(
+        products_node,
+        "attribute",
+        {"label": "product.yield.managed.total"},
+    )
+    et.SubElement(
+        product_yield_total,
+        "expression",
+        {
+            "statement": product_curve_expr,
+            "by": "1",
+            "ignoreMissingAttributes": "false",
+        },
+    )
+    product_yield_state = et.SubElement(
+        products_node,
+        "attribute",
+        {"label": f"'product.yield.managed.state.'+{runtime_state_expr}"},
+    )
+    et.SubElement(
+        product_yield_state,
+        "expression",
+        {
+            "statement": product_curve_expr,
+            "by": "1",
+            "ignoreMissingAttributes": "false",
+        },
+    )
+    for share_column, species_label in managed_share_label_map.items():
+        product_indsp_attr = et.SubElement(
+            products_node,
+            "attribute",
+            {"label": f"product.yield.managed.indsp.{species_label}"},
+        )
+        ct_product_species_fraction_expr = _ct_product_species_fraction_expr(
+            share_column,
+            origin_share_lookup_exprs,
+        )
+        et.SubElement(
+            product_indsp_attr,
+            "expression",
+            {
+                "statement": (
+                    f"{product_curve_expr}*("
+                    f"if(startswith(treatment,'CT'),"
+                    f"{ct_product_species_fraction_expr},"
+                    f"{origin_share_lookup_exprs[share_column]}))"
+                ),
+                "by": "1",
+                "ignoreMissingAttributes": "false",
+            },
+        )
+    product_yield_treat = et.SubElement(
+        products_node,
+        "attribute",
+        {"label": "'product.yield.managed.treat.'+treatment"},
+    )
+    et.SubElement(
+        product_yield_treat,
+        "expression",
+        {
+            "statement": product_curve_expr,
+            "by": "1",
+            "ignoreMissingAttributes": "false",
+        },
+    )
+    validate_forestmodel_xml_tree(
+        root=forestmodel_root,
+        required_define_fields=(
+            "status",
+            "origin",
+            "statecode",
+            "au",
+            "auf",
+            "oper",
+            "ct",
+            "aux",
+            "hasnatcurve",
+            "treatment",
+            "managed",
+            "unmanaged",
+            "operable",
+            "lowoper",
+            "frd",
+        ),
+        required_curve_ids=("unity", "le10"),
+        require_cc_treatment=True,
+    )
+    write_forestmodel_xml(root=forestmodel_root, path=forestmodel_xml_path)
+
+    headless_runtime_common_path.write_text(
+        dedent(
+            """
+            /*
+             * Shared helpers for FEMIC-triggered no-GUI Patchworks runs.
+             * MKRF canonical runtime variant: lowercase managed yield targets.
+             */
+
+            boolean femicHeadlessMode = false;
+            String femicHeadlessStageLabel = "headless_runs/femic";
+            int femicHeadlessIterations = 1;
+            double femicHeadlessImprovement = 0.0d;
+            String femicHeadlessTraceLogPath = null;
+            String femicHeadlessScenarioMode = "none";
+            String femicHeadlessScenarioTargetLabel = null;
+            Double femicHeadlessScenarioMinAnnual = null;
+
+            String femicThrowableToString(Throwable ex) {
+               java.io.StringWriter sw = new java.io.StringWriter();
+               java.io.PrintWriter pw = new java.io.PrintWriter(sw);
+               ex.printStackTrace(pw);
+               pw.flush();
+               return sw.toString();
+            }
+
+            void femicHeadlessTrace(String message) {
+               String line = "[FEMIC headless] " + message;
+               print(line);
+               if (femicHeadlessTraceLogPath == null || femicHeadlessTraceLogPath.trim().length() == 0)
+                  return;
+
+               java.io.PrintWriter writer = null;
+               try {
+                  java.io.File traceFile = new java.io.File(femicHeadlessTraceLogPath);
+                  java.io.File parent = traceFile.getParentFile();
+                  if (parent != null)
+                     parent.mkdirs();
+                  writer = new java.io.PrintWriter(new java.io.FileWriter(traceFile, true));
+                  writer.println(line);
+                  writer.flush();
+               } catch (Throwable ex) {
+                  print("[FEMIC headless] trace write failed: " + ex);
+               } finally {
+                  if (writer != null)
+                     writer.close();
+               }
+            }
+
+            boolean femicConfigureHeadlessFromArgs() {
+               if (args == void || args.length < 2)
+                  return false;
+
+               if (!"__femic_headless__".equals(args[1]))
+                  return false;
+
+               femicHeadlessMode = true;
+
+               if (args.length >= 3 && args[2] != null && args[2].trim().length() > 0)
+                  femicHeadlessStageLabel = args[2].trim();
+
+               if (args.length >= 4 && args[3] != null && args[3].trim().length() > 0)
+                  femicHeadlessIterations = Integer.parseInt(args[3].trim());
+
+               if (args.length >= 5 && args[4] != null && args[4].trim().length() > 0)
+                  femicHeadlessImprovement = Double.parseDouble(args[4].trim());
+
+               if (args.length >= 6 && args[5] != null && args[5].trim().length() > 0)
+                  femicHeadlessTraceLogPath = args[5].trim();
+
+               if (args.length >= 7 && args[6] != null && args[6].trim().length() > 0)
+                  femicHeadlessScenarioMode = args[6].trim();
+
+               if (args.length >= 8 && args[7] != null && args[7].trim().length() > 0)
+                  femicHeadlessScenarioTargetLabel = args[7].trim();
+
+               if (args.length >= 9 && args[8] != null && args[8].trim().length() > 0)
+                  femicHeadlessScenarioMinAnnual = new Double(Double.parseDouble(args[8].trim()));
+
+               femicHeadlessTrace("mode enabled: stage="
+                                  + femicHeadlessStageLabel
+                                  + " iterations="
+                                  + femicHeadlessIterations
+                                  + " improvement="
+                                  + femicHeadlessImprovement
+                                  + " scenario_mode="
+                                  + femicHeadlessScenarioMode
+                                  + " scenario_target="
+                                  + femicHeadlessScenarioTargetLabel
+                                  + " scenario_min_annual="
+                                  + femicHeadlessScenarioMinAnnual
+                                  + " trace="
+                                  + femicHeadlessTraceLogPath);
+               return true;
+            }
+
+            void femicConfigureHeadlessScenario() {
+               String mode = femicHeadlessScenarioMode == null ? "none" : femicHeadlessScenarioMode.trim();
+               if (mode.length() == 0 || "none".equalsIgnoreCase(mode)) {
+                  femicHeadlessTrace("no headless scenario mode requested");
+                  return;
+               }
+
+               if ("max-even-flow-smoke".equalsIgnoreCase(mode)) {
+                  String targetLabel = femicHeadlessScenarioTargetLabel;
+                  if (targetLabel == null || targetLabel.trim().length() == 0)
+                     targetLabel = "product.yield.managed.total";
+
+                  double minAnnual = 1000.0d;
+                  if (femicHeadlessScenarioMinAnnual != null)
+                     minAnnual = femicHeadlessScenarioMinAnnual.doubleValue();
+
+                  Target target = control.getTarget(targetLabel);
+                  if (target == null)
+                     throw new IllegalStateException("Missing headless scenario target: " + targetLabel);
+
+                  femicHeadlessTrace("validated max-even-flow smoke target="
+                                     + targetLabel
+                                     + " minAnnual="
+                                     + minAnnual);
+                  return;
+               }
+
+               throw new IllegalStateException("Unsupported FEMIC headless scenario mode: " + mode);
+            }
+
+            void femicConfigureHeadlessBaseHarvestTarget(String targetLabel, double minAnnual) {
+               Target target = control.getTarget(targetLabel);
+               if (target == null)
+                  throw new IllegalStateException("Missing headless scenario target: " + targetLabel);
+
+               target.setActive(true);
+               target.setMinActive(true);
+               target.setMaxActive(true);
+               target.setLinear(true);
+
+               target.setMaximum(200000f, 0);
+               for (int i = 1; i < Horizon.periods; i++) {
+                  target.setMinimum((float)(minAnnual * Horizon.intervals[i]), i);
+                  target.setMaximum(200000f, i);
+               }
+            }
+
+            void femicConfigureHeadlessEvenFlowTarget(String targetLabel) {
+               Target target = control.getTarget(targetLabel);
+               if (target == null)
+                  throw new IllegalStateException("Missing headless scenario target: " + targetLabel);
+
+               target.setActive(true);
+               target.setMinActive(true);
+               target.setMaxActive(true);
+
+               for (int i = 0; i < Horizon.periods; i++) {
+                  target.setMinimum(0f, i);
+                  target.setMaximum(0f, i);
+                  target.setMinWeight(100f, i);
+                  target.setMaxWeight(100f, i);
+               }
+            }
+
+            void femicWaitHeadlessIterations(int waitCount) {
+               if (waitCount <= 0) {
+                  femicHeadlessTrace("wait count <= 0; skipping scheduler wait");
+                  return;
+               }
+
+               if (femicHeadlessImprovement > 0.0d)
+                  femicHeadlessTrace("waiting for progress: attempts="
+                                     + waitCount
+                                     + " improvement="
+                                     + femicHeadlessImprovement);
+               else
+                  femicHeadlessTrace("waiting for iterations: attempts=" + waitCount);
+
+               if (femicHeadlessImprovement > 0.0d)
+                  control.waitForProgress(waitCount, femicHeadlessImprovement);
+               else
+                  control.waitForIterations(waitCount);
+
+               femicHeadlessTrace("wait completed; isSuspended=" + control.isSuspended());
+            }
+
+            void femicRunHeadlessStage() {
+               try {
+                  femicHeadlessTrace("run stage entered; isSuspended=" + control.isSuspended());
+                  femicConfigureHeadlessScenario();
+
+                  if ("max-even-flow-smoke".equalsIgnoreCase(femicHeadlessScenarioMode)) {
+                     String requestedTargetLabel = femicHeadlessScenarioTargetLabel;
+                     if (requestedTargetLabel == null || requestedTargetLabel.trim().length() == 0)
+                        requestedTargetLabel = "product.yield.managed.total";
+
+                     String baseTargetLabel = requestedTargetLabel;
+                     if (requestedTargetLabel.startsWith("flow.even."))
+                        baseTargetLabel = requestedTargetLabel.substring("flow.even.".length());
+
+                     String flowTargetLabel = "flow.even." + baseTargetLabel;
+                     double minAnnual = 1000.0d;
+                     if (femicHeadlessScenarioMinAnnual != null)
+                        minAnnual = femicHeadlessScenarioMinAnnual.doubleValue();
+
+                     femicConfigureHeadlessBaseHarvestTarget(baseTargetLabel, minAnnual);
+                     femicHeadlessTrace("seeded underlying harvest target="
+                                        + baseTargetLabel
+                                        + " minAnnual="
+                                        + minAnnual
+                                        + " linear=true max=200000");
+
+                     int seedIterations = femicHeadlessIterations;
+                     int flowIterations = 0;
+                     if (control.getTarget(flowTargetLabel) != null && femicHeadlessIterations > 1) {
+                        seedIterations = Math.max(1, femicHeadlessIterations / 2);
+                        flowIterations = femicHeadlessIterations - seedIterations;
+                     }
+
+                     femicHeadlessTrace("delegating scheduler start to waitFor*; initial isSuspended="
+                                        + control.isSuspended());
+                     femicWaitHeadlessIterations(seedIterations);
+
+                     if (flowIterations > 0) {
+                        if (!control.isSuspended()) {
+                           femicHeadlessTrace("issuing suspend between seed and flow phases");
+                           control.suspend();
+                        }
+
+                        femicConfigureHeadlessEvenFlowTarget(flowTargetLabel);
+                        femicHeadlessTrace("activated even-flow companion target="
+                                           + flowTargetLabel
+                                           + " target=0 weight=100 after seed phase");
+                        femicHeadlessTrace("delegating scheduler restart to waitFor* after seed phase; initial isSuspended="
+                                           + control.isSuspended());
+                        femicWaitHeadlessIterations(flowIterations);
+                     }
+                  } else if (femicHeadlessIterations > 0) {
+                     femicHeadlessTrace("delegating scheduler start to waitFor*; initial isSuspended="
+                                        + control.isSuspended());
+                     femicWaitHeadlessIterations(femicHeadlessIterations);
+                  } else {
+                     femicHeadlessTrace("iterations <= 0; skipping scheduler wait");
+                  }
+               } finally {
+                  if (!control.isSuspended()) {
+                     femicHeadlessTrace("issuing suspend after wait");
+                     control.suspend();
+                  } else {
+                     femicHeadlessTrace("scheduler already suspended before cleanup");
+                  }
+               }
+
+               femicHeadlessTrace("saving stage " + femicHeadlessStageLabel);
+               reportWriter.saveStage(femicHeadlessStageLabel);
+               femicHeadlessTrace("saveStage completed");
+            }
+
+            void femicQueueHeadlessStage() {
+               if (!femicHeadlessMode)
+                  return;
+
+               Runnable worker = new Runnable() {
+                  public void run() {
+                     try {
+                        femicHeadlessTrace("worker thread started");
+                        femicHeadlessTrace("waiting until initialized");
+                        control.waitUntilInitialized();
+                        femicHeadlessTrace("waitUntilInitialized completed");
+                        femicRunHeadlessStage();
+                     } catch (InterruptedException ex) {
+                        femicHeadlessTrace("stage interrupted: " + ex);
+                     } catch (Throwable ex) {
+                        femicHeadlessTrace("stage failed: " + ex);
+                        femicHeadlessTrace(femicThrowableToString(ex));
+                        ex.printStackTrace();
+                     }
+                  }
+               };
+
+               Thread headlessThread = new Thread(worker, "femic-headless-stage");
+               headlessThread.setDaemon(false);
+               femicHeadlessTrace("starting worker thread");
+               headlessThread.start();
+            }
+            """
+        ).strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    flow_targets_script_path.write_text(
+        dedent(
+            """
+            /*************************************************************
+             *
+             * Configure flow ratio accounts for managed yield accounts.
+             * MKRF canonical runtime variant: lowercase managed yield accounts.
+             *
+             *************************************************************/
+
+            _resolveAccountsFile(String tracksPathPrefix) {
+               String accountsPath = "../tracks/accounts.csv";
+               if (tracksPathPrefix != null) {
+                  accountsPath = tracksPathPrefix + "accounts.csv";
+               }
+
+               File accountsFile = AttributeStore.absoluteFile(accountsPath);
+               if (accountsFile == null) {
+                  accountsFile = new File(accountsPath).getAbsoluteFile();
+               }
+               return accountsFile;
+            }
+
+            _collectAccounts(String prefix, String tracksPathPrefix) {
+               TreeSet out = new TreeSet();
+               File accountsFile = _resolveAccountsFile(tracksPathPrefix);
+               if (!accountsFile.exists()) {
+                  throw new IllegalStateException("Missing tracks/accounts.csv: " + accountsFile.getPath());
+               }
+
+               BufferedReader reader = new BufferedReader(new FileReader(accountsFile));
+               try {
+                  String line = null;
+                  boolean first = true;
+                  while ((line = reader.readLine()) != null) {
+                     if (first) {
+                        first = false;
+                        continue;
+                     }
+                     String[] parts = line.split(",");
+                     if (parts.length < 3) {
+                        continue;
+                     }
+                     String account = parts[2].trim();
+                     if (account.startsWith(prefix)) {
+                        out.add(account);
+                     }
+                  }
+               } finally {
+                  reader.close();
+               }
+
+               return out;
+            }
+
+            setupYieldFlowTargets(control, int periods) {
+               setupYieldFlowTargets(control, periods, null);
+            }
+
+            setupYieldFlowTargets(control, int periods, String tracksPathPrefix) {
+               FlowSpec evenflow = new FlowSpec().even();
+               int ndyStart = Math.max(1, periods - 9);
+               FlowSpec ndyflow = new FlowSpec().ndy(ndyStart, periods, -1);
+
+               TreeSet productAccounts = _collectAccounts("product.yield.managed.", tracksPathPrefix);
+               TreeSet featureAccounts = _collectAccounts("feature.yield.managed.", tracksPathPrefix);
+
+               for (Iterator it = productAccounts.iterator(); it.hasNext();) {
+                  String account = (String)it.next();
+                  control.addFlowRatioAccount("flow.even." + account, account, evenflow, 100);
+               }
+
+               for (Iterator it = featureAccounts.iterator(); it.hasNext();) {
+                  String account = (String)it.next();
+                  control.addFlowRatioAccount("flow.ndy." + account, account, ndyflow, 100);
+               }
+
+               print("Configured flow targets: even=" + productAccounts.size() + " ndy=" + featureAccounts.size());
+            }
+            """
+        ).strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    analysis_pin_path.write_text(
+        dedent(
+            """
+            /*
+             * Minimal canonical MKRF Patchworks control lane.
+             * Generated by FEMIC for headless/runtime smoke use.
+             */
+
+            int periods = 30;
+            Horizon.setHorizon(periods, 10);
+
+            boolean useRoutes = false;
+            boolean usePatches = false;
+
+            String tracks_path_prefix = "../tracks/";
+            sourceRelative("headless_runtime_common.bsh");
+            sourceRelative("../scripts/targets/flowtargets.bsh");
+
+            blocks = tracks_path_prefix + "blocks.csv";
+            curves = tracks_path_prefix + "curves.csv";
+            features = tracks_path_prefix + "features.csv";
+            products = tracks_path_prefix + "products.csv";
+            tracknames = tracks_path_prefix + "tracknames.csv";
+            treatments = tracks_path_prefix + "treatments.csv";
+            accounts = tracks_path_prefix + "accounts.csv";
+            stratas = tracks_path_prefix + "strata.csv";
+            if (
+                AttributeStore.absoluteFile(tracks_path_prefix + "packages.csv").exists()
+                && AttributeStore.absoluteFile(tracks_path_prefix + "packageSequences.csv").exists()
+            ) {
+               packages = tracks_path_prefix + "packages.csv";
+               sequences = tracks_path_prefix + "packageSequences.csv";
+            }
+
+            block_shape = "../spatial/fragments.shp";
+            block_key = "RES_KEY";
+
+            int Patchworks_TargetInit() {
+               setupYieldFlowTargets(control, periods, tracks_path_prefix);
+               return 1;
+            }
+
+            int PatchWorks_Init() {
+               femicConfigureHeadlessFromArgs();
+
+               if (!femicHeadlessMode) {
+                  classic_GUI(control);
+
+                  DefaultTheme def = new DefaultTheme(
+                     blockData,
+                     new PolygonSymbol(new Color(239, 239, 239))
+                  );
+                  def.setCaption("Forest Outline");
+                  Layer defLayer = new GeoRelLayer(blockData, def);
+                  layers.add(defLayer);
+
+                  NumericTheme ageClassTheme = new NumericTheme(blockData);
+                  ageClassTheme.setFieldname("0.5 * (MANAGEDOFFSET + UNMANAGEDOFFSET)");
+                  ageClassTheme.addElement(
+                     new ThemeElement(
+                        "age_000_019",
+                        new PolygonSymbol(new Color(255, 255, 229))
+                     ),
+                     "0 - 19"
+                  );
+                  ageClassTheme.addElement(
+                     new ThemeElement(
+                        "age_020_039",
+                        new PolygonSymbol(new Color(248, 252, 193))
+                     ),
+                     "20 - 39"
+                  );
+                  ageClassTheme.addElement(
+                     new ThemeElement(
+                        "age_040_059",
+                        new PolygonSymbol(new Color(229, 244, 171))
+                     ),
+                     "40 - 59"
+                  );
+                  ageClassTheme.addElement(
+                     new ThemeElement(
+                        "age_060_079",
+                        new PolygonSymbol(new Color(199, 232, 154))
+                     ),
+                     "60 - 79"
+                  );
+                  ageClassTheme.addElement(
+                     new ThemeElement(
+                        "age_080_099",
+                        new PolygonSymbol(new Color(162, 216, 137))
+                     ),
+                     "80 - 99"
+                  );
+                  ageClassTheme.addElement(
+                     new ThemeElement(
+                        "age_100_119",
+                        new PolygonSymbol(new Color(120, 198, 121))
+                     ),
+                     "100 - 119"
+                  );
+                  ageClassTheme.addElement(
+                     new ThemeElement(
+                        "age_120_139",
+                        new PolygonSymbol(new Color(76, 176, 98))
+                     ),
+                     "120 - 139"
+                  );
+                  ageClassTheme.addElement(
+                     new ThemeElement(
+                        "age_140_159",
+                        new PolygonSymbol(new Color(47, 147, 77))
+                     ),
+                     "140 - 159"
+                  );
+                  ageClassTheme.addElement(
+                     new ThemeElement(
+                        "age_160_179",
+                        new PolygonSymbol(new Color(20, 120, 62))
+                     ),
+                     "160 - 179"
+                  );
+                  ageClassTheme.addElement(
+                     new ThemeElement(
+                        "age_180_199",
+                        new PolygonSymbol(new Color(0, 97, 52))
+                     ),
+                     "180 - 199"
+                  );
+                  ageClassTheme.addElement(
+                     new ThemeElement(
+                        "age_200plus",
+                        new PolygonSymbol(new Color(0, 69, 41))
+                     ),
+                     "200 - 99999"
+                  );
+                  ageClassTheme.setCaption("Age Class (20-year)");
+                  ageClassTheme.setUnclassified(new ThemeElement("", PolygonSymbol.erase));
+                  blockData.addTheme(ageClassTheme);
+                  GeoRelLayer ageClassLayer = new GeoRelLayer(blockData, ageClassTheme);
+                  ageClassLayer.setVisible(false);
+                  layers.add(ageClassLayer);
+
+                  UniqueValueTheme currTreatTheme = new UniqueValueTheme(blockData);
+                  currTreatTheme.setFieldname("CURRENTTREATMENT");
+                  currTreatTheme.addElement(
+                     new ThemeElement(
+                        "CC",
+                        PolygonSymbol.getDefault(Symbol.FILL, Symbol.GEMS, 0)
+                     ),
+                     "CC"
+                  );
+                  currTreatTheme.addElement(
+                     new ThemeElement(
+                        "CT35",
+                        PolygonSymbol.getDefault(Symbol.FILL, Symbol.GEMS, 1)
+                     ),
+                     "CT35"
+                  );
+                  currTreatTheme.addElement(
+                     new ThemeElement(
+                        "CT40",
+                        PolygonSymbol.getDefault(Symbol.FILL, Symbol.GEMS, 2)
+                     ),
+                     "CT40"
+                  );
+                  currTreatTheme.addElement(
+                     new ThemeElement(
+                        "CT45",
+                        PolygonSymbol.getDefault(Symbol.FILL, Symbol.GEMS, 3)
+                     ),
+                     "CT45"
+                  );
+                  currTreatTheme.setCaption("Current Treatments");
+                  currTreatTheme.setUnclassified(new ThemeElement("", PolygonSymbol.erase));
+                  blockData.addTheme(currTreatTheme);
+                  GeoRelLayer currTreatLayer = new GeoRelLayer(blockData, currTreatTheme);
+                  currTreatLayer.setVisible(false);
+                  layers.add(currTreatLayer);
+
+                  UniqueValueTheme latestTreatTheme = new UniqueValueTheme(blockData);
+                  latestTreatTheme.setFieldname("LASTTREATMENT");
+                  latestTreatTheme.addElement(
+                     new ThemeElement(
+                        "CC",
+                        PolygonSymbol.getDefault(Symbol.FILL, Symbol.GEMS, 0)
+                     ),
+                     "CC"
+                  );
+                  latestTreatTheme.addElement(
+                     new ThemeElement(
+                        "CT35",
+                        PolygonSymbol.getDefault(Symbol.FILL, Symbol.GEMS, 1)
+                     ),
+                     "CT35"
+                  );
+                  latestTreatTheme.addElement(
+                     new ThemeElement(
+                        "CT40",
+                        PolygonSymbol.getDefault(Symbol.FILL, Symbol.GEMS, 2)
+                     ),
+                     "CT40"
+                  );
+                  latestTreatTheme.addElement(
+                     new ThemeElement(
+                        "CT45",
+                        PolygonSymbol.getDefault(Symbol.FILL, Symbol.GEMS, 3)
+                     ),
+                     "CT45"
+                  );
+                  latestTreatTheme.setCaption("Latest Treatments");
+                  latestTreatTheme.setUnclassified(new ThemeElement("", PolygonSymbol.erase));
+                  blockData.addTheme(latestTreatTheme);
+                  GeoRelLayer latestTreatLayer = new GeoRelLayer(blockData, latestTreatTheme);
+                  latestTreatLayer.setVisible(false);
+                  layers.add(latestTreatLayer);
+
+                  if (usePatches) {
+                     NumericTheme patch0Theme = new NumericTheme(blockData);
+                     patch0Theme.setFieldname("product.area.managed.treat.CC.size");
+                     patch0Theme.addElement(
+                        new ThemeElement(
+                           "0_1",
+                           PolygonSymbol.getDefault(Symbol.FILL, Symbol.APPLE, 0)
+                        ),
+                        "0.001 - 1.0"
+                     );
+                     patch0Theme.addElement(
+                        new ThemeElement(
+                           "1_5",
+                           PolygonSymbol.getDefault(Symbol.FILL, Symbol.APPLE, 1)
+                        ),
+                        "1.0 - 5.0"
+                     );
+                     patch0Theme.addElement(
+                        new ThemeElement(
+                           "5_40",
+                           PolygonSymbol.getDefault(Symbol.FILL, Symbol.APPLE, 2)
+                        ),
+                        "5.0 - 40.0"
+                     );
+                     patch0Theme.addElement(
+                        new ThemeElement(
+                           "40_50",
+                           PolygonSymbol.getDefault(Symbol.FILL, Symbol.APPLE, 3)
+                        ),
+                        "40.0 - 50.0"
+                     );
+                     patch0Theme.addElement(
+                        new ThemeElement(
+                           "50plus",
+                           PolygonSymbol.getDefault(Symbol.FILL, Symbol.APPLE, 4)
+                        ),
+                        "50.0 - 99999.0"
+                     );
+                     patch0Theme.setCaption("patch.grpblk patches");
+                     patch0Theme.setUnclassified(new ThemeElement("", PolygonSymbol.erase));
+                     blockData.addTheme(patch0Theme);
+                     GeoRelLayer patch0Layer = new GeoRelLayer(blockData, patch0Theme);
+                     layers.add(patch0Layer);
+
+                     NumericTheme patch1Theme = new NumericTheme(blockData);
+                     patch1Theme.setFieldname("feature.area.managed.seral.le10.size");
+                     patch1Theme.addElement(
+                        new ThemeElement(
+                           "0_40",
+                           PolygonSymbol.getDefault(Symbol.FILL, Symbol.APPLE, 0)
+                        ),
+                        "0.001 - 40.0"
+                     );
+                     patch1Theme.addElement(
+                        new ThemeElement(
+                           "40_50",
+                           PolygonSymbol.getDefault(Symbol.FILL, Symbol.APPLE, 1)
+                        ),
+                        "40.0 - 50.0"
+                     );
+                     patch1Theme.addElement(
+                        new ThemeElement(
+                           "50plus",
+                           PolygonSymbol.getDefault(Symbol.FILL, Symbol.APPLE, 2)
+                        ),
+                        "50.0 - 99999.0"
+                     );
+                     patch1Theme.setCaption("patch.sepblk patches");
+                     patch1Theme.setUnclassified(new ThemeElement("", PolygonSymbol.erase));
+                     blockData.addTheme(patch1Theme);
+                     GeoRelLayer patch1Layer = new GeoRelLayer(blockData, patch1Theme);
+                     layers.add(patch1Layer);
+                  }
+               }
+
+               if (femicHeadlessMode)
+                  femicQueueHeadlessStage();
+
+               return 1;
+            }
+            """
+        ).strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    manifest_payload = {
+        "schema_version": 1,
+        "package_root": _manifest_path_value(package_root),
+        "runtime_generation_status": "initialized_only",
+        "source_contracts": {
+            "selected_au_csv": _manifest_path_value(selected_au_csv),
+            "stand_origin_assignment_csv": _manifest_path_value(
+                stand_origin_assignment_csv
+            ),
+            "stand_au_assignment_csv": _manifest_path_value(stand_au_assignment_csv),
+            "managed_bootstrap_csv": _manifest_path_value(managed_bootstrap_csv),
+            "first_growth_curves_csv": _manifest_path_value(first_growth_curves_csv),
+            "first_growth_diagnostics_csv": _manifest_path_value(
+                first_growth_diagnostics_csv
+            ),
+            "managed_curves_csv": _manifest_path_value(managed_curves_csv),
+            "managed_run_manifest_json": _manifest_path_value(
+                managed_run_manifest_json
+            ),
+            "bad_curve_audit_summary_csv": _manifest_path_value(
+                bad_curve_audit_summary_csv
+            ),
+            "runtime_curve_status_csv": _manifest_path_value(curve_status_path),
+            "analysis_au_runtime_status_csv": _manifest_path_value(
+                analysis_au_runtime_status_path
+            ),
+            "analysis_au_curve_refs_csv": _manifest_path_value(
+                analysis_au_curve_refs_path
+            ),
+            "runtime_au_remap_audit_csv": _manifest_path_value(
+                runtime_au_remap_audit_path
+            ),
+            "runtime_species_share_audit_csv": _manifest_path_value(
+                species_share_audit_path
+            ),
+            "ct_eligibility_audit_csv": _manifest_path_value(ct_eligibility_audit_path),
+            "ct_intensity_audit_csv": _manifest_path_value(ct_intensity_audit_path),
+            "ct_intensity_summary_csv": _manifest_path_value(ct_intensity_summary_path),
+            "hw_ingrowth_overlay_audit_csv": _manifest_path_value(
+                hw_ingrowth_overlay_audit_path
+            ),
+            "hw_ingrowth_overlay_summary_csv": _manifest_path_value(
+                hw_ingrowth_overlay_summary_path
+            ),
+            "runtime_curve_contract_xml": _manifest_path_value(xml_contract_path),
+            "runtime_curve_bank_xml": _manifest_path_value(xml_curve_bank_path),
+            "forestmodel_xml": _manifest_path_value(forestmodel_xml_path),
+            "analysis_pin": _manifest_path_value(analysis_pin_path),
+            "headless_runtime_common_bsh": _manifest_path_value(
+                headless_runtime_common_path
+            ),
+            "flow_targets_bsh": _manifest_path_value(flow_targets_script_path),
+        },
+        "counts": {
+            "selected_au_count": selected_au_count,
+            "first_growth_curve_au_count": first_growth_curve_au_count,
+            "first_growth_missing_au_count": first_growth_missing_au_count,
+            "managed_curve_au_count": managed_curve_au_count,
+            "bad_curve_flagged_au_count": flagged_au_count,
+            "managed_only_runtime_au_count": int(
+                runtime_curve_status["runtime_curve_mode"].eq("managed_only").sum()
+            ),
+        },
+        "runtime_au_normalization": {
+            "selected_passthrough_count": int((~remap_audit["was_remapped"]).sum()),
+            "remapped_source_au_count": int(remap_audit["was_remapped"].sum()),
+            "remapped_forest_cover_id_count": int(
+                remap_audit.loc[
+                    remap_audit["was_remapped"], "forest_cover_id_count"
+                ].sum()
+            ),
+        },
+        "curve_policy": {
+            "first_growth_curve_family": "smoothed_bin_pchip",
+            "first_growth_borrowing_allowed": False,
+            "managed_only_runtime_units_allowed": True,
+        },
+        "managed_only_runtime_policy": {
+            "insufficient_support_requires_first_growth_curve": False,
+            "insufficient_support_fallback_generation": "forbidden",
+            "insufficient_support_borrowing": "forbidden",
+        },
+        "managed_run_summary": {
+            "status": managed_manifest.get("status"),
+            "curve_au_count": managed_manifest.get("curve_au_count"),
+            "included_au_count": managed_manifest.get("included_au_count"),
+        },
+    }
+    manifest_path.write_text(
+        json.dumps(manifest_payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    if not readme_path.exists():
+        readme_path.write_text(
+            "\n".join(
+                [
+                    "# MKRF Patchworks Canonical Rebuild Package",
+                    "",
+                    "This directory is the target home for the source-faithful MKRF rebuild package",
+                    "tracked under `P60.8+`.",
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+    return MkrfRuntimePackageInitResult(
+        package_root=package_root,
+        readme_path=readme_path,
+        manifest_path=manifest_path,
+        curve_status_path=curve_status_path,
+        analysis_au_runtime_status_path=analysis_au_runtime_status_path,
+        analysis_au_curve_refs_path=analysis_au_curve_refs_path,
+        runtime_au_remap_audit_path=runtime_au_remap_audit_path,
+        species_share_audit_path=species_share_audit_path,
+        ct_eligibility_audit_path=ct_eligibility_audit_path,
+        ct_intensity_audit_path=ct_intensity_audit_path,
+        ct_intensity_summary_path=ct_intensity_summary_path,
+        hw_ingrowth_overlay_audit_path=hw_ingrowth_overlay_audit_path,
+        hw_ingrowth_overlay_summary_path=hw_ingrowth_overlay_summary_path,
+        analysis_pin_path=analysis_pin_path,
+        headless_runtime_common_path=headless_runtime_common_path,
+        flow_targets_script_path=flow_targets_script_path,
+        xml_contract_path=xml_contract_path,
+        xml_curve_bank_path=xml_curve_bank_path,
+        forestmodel_xml_path=forestmodel_xml_path,
+        selected_au_count=selected_au_count,
+        first_growth_curve_au_count=first_growth_curve_au_count,
+        first_growth_missing_au_count=first_growth_missing_au_count,
+        managed_curve_au_count=managed_curve_au_count,
+    )
+
+
+def _read_track_attribute_labels(csv_path: Path) -> set[str]:
+    if not csv_path.exists():
+        return set()
+    frame = pd.read_csv(csv_path)
+    for column in ("ATTRIBUTE", "attribute", "LABEL", "label"):
+        if column in frame.columns:
+            return set(frame[column].astype(str).str.strip())
+    return set()
+
+
+def _target_signal_status(target_csv_path: Path) -> tuple[bool, float | None]:
+    if not target_csv_path.exists():
+        return False, None
+    frame = pd.read_csv(target_csv_path)
+    if "CURRENT" not in frame.columns:
+        return False, None
+    current = pd.to_numeric(frame["CURRENT"], errors="coerce").fillna(0.0)
+    max_signal = float(current.abs().max()) if not current.empty else 0.0
+    return bool(max_signal > 0), max_signal
+
+
+def audit_mkrf_runtime_sanity(
+    *,
+    package_root: Path,
+    stage_dir: Path,
+) -> MkrfRuntimeSanityAuditResult:
+    """Audit canonical MKRF runtime signal against published species-share sources."""
+    package_root = package_root.resolve()
+    stage_dir = stage_dir.resolve()
+    analysis_dir = package_root / "analysis"
+    tracks_dir = package_root / "tracks"
+    targets_dir = stage_dir / "targets"
+    sanity_dir = stage_dir / "sanity"
+    sanity_dir.mkdir(parents=True, exist_ok=True)
+    audit_csv_path = sanity_dir / "mkrf_runtime_sanity_audit.csv"
+    summary_json_path = sanity_dir / "mkrf_runtime_sanity_summary.json"
+    species_share_audit_path = analysis_dir / "runtime_species_share_audit.csv"
+
+    species_share_audit = pd.read_csv(species_share_audit_path)
+    accounts_labels = _read_track_attribute_labels(tracks_dir / "accounts.csv")
+    feature_labels = _read_track_attribute_labels(tracks_dir / "features.csv")
+    product_labels = _read_track_attribute_labels(tracks_dir / "products.csv")
+
+    rows: list[dict[str, object]] = []
+    for ifm_lane, surface in (
+        ("managed", "feature"),
+        ("unmanaged", "feature"),
+        ("managed", "product"),
+    ):
+        for bucket in _SPECIES_BUCKETS:
+            label = f"{surface}.yield.{ifm_lane}.indsp.{bucket}"
+            target_csv_path = targets_dir / f"{label.replace('.', '_')}.csv"
+            target_has_signal, target_max_current = _target_signal_status(
+                target_csv_path
+            )
+            track_labels = feature_labels if surface == "feature" else product_labels
+            account_present = label in accounts_labels
+            track_present = label in track_labels
+            target_file_present = target_csv_path.exists()
+            source_rows = species_share_audit.loc[
+                species_share_audit["species_bucket"].astype(str).eq(bucket)
+            ].copy()
+            natural_nonzero = bool(
+                pd.to_numeric(
+                    source_rows.loc[
+                        source_rows["origin_lane"].astype(str).eq("natural"),
+                        "share_pct",
+                    ],
+                    errors="coerce",
+                )
+                .fillna(0.0)
+                .gt(0)
+                .any()
+            )
+            treated_nonzero = bool(
+                pd.to_numeric(
+                    source_rows.loc[
+                        source_rows["origin_lane"].astype(str).eq("treated"),
+                        "share_pct",
+                    ],
+                    errors="coerce",
+                )
+                .fillna(0.0)
+                .gt(0)
+                .any()
+            )
+            any_source_nonzero = natural_nonzero or treated_nonzero
+            if not account_present and not track_present and not target_file_present:
+                audit_status = "not_emitted"
+            elif target_has_signal and not any_source_nonzero:
+                audit_status = "fail_signal_without_source_share"
+            elif account_present and track_present and not target_file_present:
+                audit_status = "fail_missing_target_output"
+            elif (not target_has_signal) and any_source_nonzero:
+                audit_status = "fail_zero_signal_with_source_share"
+            elif target_has_signal and any_source_nonzero:
+                audit_status = "pass_signal_matches_source_share"
+            else:
+                audit_status = "pass_zero_signal_zero_source_share"
+            rows.append(
+                {
+                    "surface": surface,
+                    "ifm_lane": ifm_lane,
+                    "species_bucket": bucket,
+                    "target_label": label,
+                    "target_csv_path": str(target_csv_path),
+                    "account_present": account_present,
+                    "track_present": track_present,
+                    "target_file_present": target_file_present,
+                    "target_has_signal": target_has_signal,
+                    "target_max_current": target_max_current,
+                    "natural_source_nonzero": natural_nonzero,
+                    "treated_source_nonzero": treated_nonzero,
+                    "any_source_nonzero": any_source_nonzero,
+                    "audit_status": audit_status,
+                }
+            )
+
+    audit_frame = pd.DataFrame(rows).sort_values(
+        ["surface", "ifm_lane", "species_bucket"],
+        kind="stable",
+    )
+    audit_frame.to_csv(audit_csv_path, index=False)
+    failure_count = int(
+        audit_frame["audit_status"].astype(str).str.startswith("fail_").sum()
+    )
+    summary_payload = {
+        "schema_version": 1,
+        "package_root": str(package_root),
+        "stage_dir": str(stage_dir),
+        "row_count": int(len(audit_frame)),
+        "failure_count": failure_count,
+        "failures": audit_frame.loc[
+            audit_frame["audit_status"].astype(str).str.startswith("fail_")
+        ].to_dict(orient="records"),
+    }
+    summary_json_path.write_text(
+        json.dumps(summary_payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return MkrfRuntimeSanityAuditResult(
+        package_root=package_root,
+        stage_dir=stage_dir,
+        audit_csv_path=audit_csv_path,
+        summary_json_path=summary_json_path,
+        row_count=int(len(audit_frame)),
+        failure_count=failure_count,
+    )

--- a/src/mkrf_freshforge/__init__.py
+++ b/src/mkrf_freshforge/__init__.py
@@ -317,8 +317,8 @@ def _default_command_runner(
     )
 
 
-def _python_m_femic(*args: str) -> tuple[str, ...]:
-    return (sys.executable, "-m", "femic", *args)
+def _python_m_mkrf_femic(*args: str) -> tuple[str, ...]:
+    return (sys.executable, "-m", "mkrf_femic", *args)
 
 
 def _parameter(node: Any, key: str) -> str:
@@ -359,8 +359,7 @@ def _command_builders() -> dict[str, Callable[[Any, Any], tuple[str, ...]]]:
 
 def _build_au_inputs_command(node: Any, _context: Any) -> tuple[str, ...]:
     command = list(
-        _python_m_femic(
-            "instance",
+        _python_m_mkrf_femic(
             "mkrf-build-au-inputs",
             "--instance-root",
             _parameter(node, "instance_root"),
@@ -374,8 +373,7 @@ def _build_au_inputs_command(node: Any, _context: Any) -> tuple[str, ...]:
 
 def _build_select_aus_command(node: Any, _context: Any) -> tuple[str, ...]:
     command = list(
-        _python_m_femic(
-            "instance",
+        _python_m_mkrf_femic(
             "mkrf-select-aus",
             "--instance-root",
             _parameter(node, "instance_root"),
@@ -390,8 +388,7 @@ def _build_select_aus_command(node: Any, _context: Any) -> tuple[str, ...]:
 
 def _build_managed_au_inputs_command(node: Any, _context: Any) -> tuple[str, ...]:
     command = list(
-        _python_m_femic(
-            "instance",
+        _python_m_mkrf_femic(
             "mkrf-build-managed-au-inputs",
             "--instance-root",
             _parameter(node, "instance_root"),
@@ -408,8 +405,7 @@ def _build_managed_au_inputs_command(node: Any, _context: Any) -> tuple[str, ...
 
 def _build_managed_au_curves_command(node: Any, _context: Any) -> tuple[str, ...]:
     command = list(
-        _python_m_femic(
-            "instance",
+        _python_m_mkrf_femic(
             "mkrf-build-managed-au-curves",
             "--instance-root",
             _parameter(node, "instance_root"),
@@ -427,8 +423,7 @@ def _build_managed_au_curves_command(node: Any, _context: Any) -> tuple[str, ...
 
 def _build_init_runtime_package_command(node: Any, _context: Any) -> tuple[str, ...]:
     command = list(
-        _python_m_femic(
-            "instance",
+        _python_m_mkrf_femic(
             "mkrf-init-runtime-package",
             "--instance-root",
             _parameter(node, "instance_root"),

--- a/tests/test_mkrf_au.py
+++ b/tests/test_mkrf_au.py
@@ -1,0 +1,267 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from pathlib import Path
+
+from mkrf_femic.pipeline.mkrf_au import (
+    build_mkrf_au_aggregation_audit,
+    build_mkrf_au_tables,
+    build_mkrf_selected_au_table,
+    ordered_top_two_species,
+    parse_mkrf_bec,
+)
+from mkrf_femic.workflows.mkrf import build_mkrf_selected_au_input_bundle
+
+
+def test_parse_mkrf_bec_splits_zone_subzone_variant() -> None:
+    assert parse_mkrf_bec("CWHvm2") == ("cwh", "vm", "2")
+    assert parse_mkrf_bec("CWHdm") == ("cwh", "dm", "x")
+    assert parse_mkrf_bec(None) == ("x", "x", "x")
+
+
+def test_ordered_top_two_species_uses_lexical_tie_break() -> None:
+    row = {
+        "TCL_1_TSP_1_TREE_SPECIES_CODE": "HW",
+        "TCL_1_TSP_1_SPECIES_PCT": 40,
+        "TCL_1_TSP_2_TREE_SPECIES_CODE": "CW",
+        "TCL_1_TSP_2_SPECIES_PCT": 40,
+        "TCL_1_TSP_3_TREE_SPECIES_CODE": "FDC",
+        "TCL_1_TSP_3_SPECIES_PCT": 20,
+    }
+    out = ordered_top_two_species(row)
+    assert out.leading_species_1 == "cw"
+    assert out.leading_species_2 == "hw"
+    assert out.tie_break_used is True
+
+
+def test_build_mkrf_au_tables_filters_non_forest_and_groups_assignments() -> None:
+    source = pd.DataFrame(
+        [
+            {
+                "RES_KEY": 10,
+                "FOREST_COVER_ID": 100,
+                "BEC": "CWHvm2",
+                "CONTCLAS": "C",
+                "TCL_1_TSP_1_TREE_SPECIES_CODE": "HW",
+                "TCL_1_TSP_1_SPECIES_PCT": 70,
+                "TCL_1_TSP_2_TREE_SPECIES_CODE": "CW",
+                "TCL_1_TSP_2_SPECIES_PCT": 30,
+            },
+            {
+                "RES_KEY": 11,
+                "FOREST_COVER_ID": 101,
+                "BEC": "CWHvm2",
+                "CONTCLAS": "C",
+                "TCL_1_TSP_1_TREE_SPECIES_CODE": "HW",
+                "TCL_1_TSP_1_SPECIES_PCT": 60,
+                "TCL_1_TSP_2_TREE_SPECIES_CODE": "CW",
+                "TCL_1_TSP_2_SPECIES_PCT": 40,
+            },
+            {
+                "RES_KEY": 12,
+                "FOREST_COVER_ID": 102,
+                "BEC": "CWHdm",
+                "CONTCLAS": "X",
+                "TCL_1_TSP_1_TREE_SPECIES_CODE": "DR",
+                "TCL_1_TSP_1_SPECIES_PCT": 100,
+            },
+        ]
+    )
+
+    au_table, assignment = build_mkrf_au_tables(source)
+
+    assert list(assignment["res_key"]) == [10, 11]
+    assert list(assignment["au_id"].unique()) == ["cwh_vm_2_hw_cw"]
+    assert list(au_table["au_id"]) == ["cwh_vm_2_hw_cw"]
+    assert list(au_table["stand_count"]) == [2]
+
+
+def test_build_mkrf_au_tables_applies_minor_strata_aggregation_auditably() -> None:
+    source = pd.DataFrame(
+        [
+            {
+                "RES_KEY": 20,
+                "FOREST_COVER_ID": 200,
+                "BEC": "CWHvm2",
+                "CONTCLAS": "C",
+                "Shape_Area": 10000.0,
+                "TCL_1_TSP_1_TREE_SPECIES_CODE": "HW",
+                "TCL_1_TSP_1_SPECIES_PCT": 60,
+                "TCL_1_TSP_2_TREE_SPECIES_CODE": "BA",
+                "TCL_1_TSP_2_SPECIES_PCT": 30,
+            },
+            {
+                "RES_KEY": 21,
+                "FOREST_COVER_ID": 201,
+                "BEC": "CWHvm2",
+                "CONTCLAS": "C",
+                "Shape_Area": 20000.0,
+                "TCL_1_TSP_1_TREE_SPECIES_CODE": "BA",
+                "TCL_1_TSP_1_SPECIES_PCT": 55,
+                "TCL_1_TSP_2_TREE_SPECIES_CODE": "HW",
+                "TCL_1_TSP_2_SPECIES_PCT": 35,
+            },
+            {
+                "RES_KEY": 22,
+                "FOREST_COVER_ID": 202,
+                "BEC": "CWHdm",
+                "CONTCLAS": "C",
+                "Shape_Area": 30000.0,
+                "TCL_1_TSP_1_TREE_SPECIES_CODE": "CW",
+                "TCL_1_TSP_1_SPECIES_PCT": 50,
+                "TCL_1_TSP_2_TREE_SPECIES_CODE": "DR",
+                "TCL_1_TSP_2_SPECIES_PCT": 40,
+            },
+        ]
+    )
+
+    au_table, assignment = build_mkrf_au_tables(source)
+    audit = build_mkrf_au_aggregation_audit(assignment)
+
+    assert assignment.loc[assignment["res_key"].eq(21), "raw_au_id"].iloc[0] == (
+        "cwh_vm_2_ba_hw"
+    )
+    assert assignment.loc[assignment["res_key"].eq(21), "au_id"].iloc[0] == (
+        "cwh_vm_2_hw_ba"
+    )
+    assert (
+        assignment.loc[assignment["res_key"].eq(21), "leading_species_1"].iloc[0]
+        == "ba"
+    )
+    assert (
+        assignment.loc[assignment["res_key"].eq(21), "leading_species_1_share"].iloc[0]
+        == 55
+    )
+
+    assert au_table["au_id"].tolist() == ["cwh_dm_x_dr_cw", "cwh_vm_2_hw_ba"]
+    merged = au_table.loc[au_table["au_id"].eq("cwh_vm_2_hw_ba")].iloc[0]
+    assert merged["stand_count"] == 2
+    assert merged["leading_species_1"] == "hw"
+    assert merged["leading_species_2"] == "ba"
+
+    aggregated_row = audit.loc[audit["raw_au_id"].eq("cwh_vm_2_ba_hw")].iloc[0]
+    assert aggregated_row["au_id"] == "cwh_vm_2_hw_ba"
+    assert bool(aggregated_row["was_aggregated"]) is True
+    assert aggregated_row["covered_area_ha"] == 2.0
+    assert aggregated_row["target_area_ha"] == 3.0
+    assert aggregated_row["raw_share_of_target_area"] == 2.0 / 3.0
+
+
+def test_build_mkrf_selected_au_table_uses_smallest_prefix_meeting_coverage() -> None:
+    au_table = pd.DataFrame(
+        [
+            {
+                "au_id": "au_c",
+                "bec_zone": "cwh",
+                "bec_subzone": "vm",
+                "bec_variant": "2",
+                "leading_species_1": "cw",
+                "leading_species_2": "hw",
+                "stand_count": 1,
+                "tie_break_record_count": 0,
+            },
+            {
+                "au_id": "au_a",
+                "bec_zone": "cwh",
+                "bec_subzone": "vm",
+                "bec_variant": "2",
+                "leading_species_1": "hw",
+                "leading_species_2": "cw",
+                "stand_count": 1,
+                "tie_break_record_count": 0,
+            },
+            {
+                "au_id": "au_b",
+                "bec_zone": "cwh",
+                "bec_subzone": "vm",
+                "bec_variant": "2",
+                "leading_species_1": "fdc",
+                "leading_species_2": "hw",
+                "stand_count": 1,
+                "tie_break_record_count": 0,
+            },
+        ]
+    )
+    assignment = pd.DataFrame(
+        [
+            {"au_id": "au_a", "shape_area_ha": 50.0},
+            {"au_id": "au_b", "shape_area_ha": 30.0},
+            {"au_id": "au_c", "shape_area_ha": 20.0},
+        ]
+    )
+
+    selected = build_mkrf_selected_au_table(au_table, assignment, target_coverage=0.8)
+
+    assert list(selected["au_id"]) == ["au_a", "au_b"]
+    assert list(selected["selected_rank"]) == [1, 2]
+    assert list(selected["covered_area_ha"]) == [50.0, 30.0]
+    assert list(selected["covered_area_share"]) == [0.5, 0.3]
+    assert list(selected["cumulative_covered_area_share"]) == [0.5, 0.8]
+    assert selected["target_coverage"].tolist() == [0.8, 0.8]
+
+
+def test_build_mkrf_selected_au_input_bundle_writes_selected_csv(
+    tmp_path: Path,
+) -> None:
+    bundle_dir = tmp_path / "data" / "model_input_bundle"
+    bundle_dir.mkdir(parents=True)
+    au_table_csv = bundle_dir / "au_table.csv"
+    assignment_csv = bundle_dir / "stand_au_assignment.csv"
+    output_csv = bundle_dir / "selected_au_table.csv"
+
+    pd.DataFrame(
+        [
+            {
+                "au_id": "au_a",
+                "bec_zone": "cwh",
+                "bec_subzone": "vm",
+                "bec_variant": "2",
+                "leading_species_1": "hw",
+                "leading_species_2": "cw",
+                "stand_count": 1,
+                "tie_break_record_count": 0,
+            },
+            {
+                "au_id": "au_b",
+                "bec_zone": "cwh",
+                "bec_subzone": "vm",
+                "bec_variant": "2",
+                "leading_species_1": "fdc",
+                "leading_species_2": "hw",
+                "stand_count": 1,
+                "tie_break_record_count": 0,
+            },
+            {
+                "au_id": "au_c",
+                "bec_zone": "cwh",
+                "bec_subzone": "vm",
+                "bec_variant": "2",
+                "leading_species_1": "cw",
+                "leading_species_2": "hw",
+                "stand_count": 1,
+                "tie_break_record_count": 0,
+            },
+        ]
+    ).to_csv(au_table_csv, index=False)
+    pd.DataFrame(
+        [
+            {"au_id": "au_a", "shape_area_ha": 50.0},
+            {"au_id": "au_b", "shape_area_ha": 30.0},
+            {"au_id": "au_c", "shape_area_ha": 20.0},
+        ]
+    ).to_csv(assignment_csv, index=False)
+
+    result = build_mkrf_selected_au_input_bundle(
+        au_table_csv=au_table_csv,
+        assignment_csv=assignment_csv,
+        output_path=output_csv,
+        target_coverage=0.8,
+    )
+
+    written = pd.read_csv(output_csv)
+    assert output_csv.exists()
+    assert list(written["au_id"]) == ["au_a", "au_b"]
+    assert result.selected_au_count == 2
+    assert result.total_au_count == 3
+    assert result.realized_coverage == 0.8

--- a/tests/test_mkrf_bad_curves.py
+++ b/tests/test_mkrf_bad_curves.py
@@ -1,0 +1,723 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from mkrf_femic.workflows.mkrf import (
+    _apply_insufficient_support_merge,
+    _apply_young_skewed_sibling_borrow,
+    build_mkrf_bad_curve_audit,
+)
+
+
+def test_build_mkrf_bad_curve_audit_writes_summary_and_detail(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    assignment_csv = tmp_path / "stand_au_assignment.csv"
+    selected_au_csv = tmp_path / "selected_au_table.csv"
+    first_growth_curves_csv = tmp_path / "first_growth_au_curves.csv"
+    vdyp_yields_csv = tmp_path / "vdyp_yields.csv"
+    output_dir = tmp_path / "out"
+
+    pd.DataFrame(
+        [
+            {
+                "res_key": 1,
+                "forest_cover_id": 101,
+                "shape_area_ha": 10.0,
+                "au_id": "au_bad",
+            },
+            {
+                "res_key": 2,
+                "forest_cover_id": 102,
+                "shape_area_ha": 12.0,
+                "au_id": "au_bad",
+            },
+            {
+                "res_key": 3,
+                "forest_cover_id": 201,
+                "shape_area_ha": 8.0,
+                "au_id": "au_ok",
+            },
+        ]
+    ).to_csv(assignment_csv, index=False)
+    pd.DataFrame(
+        [
+            {"au_id": "au_bad", "selected_rank": 1, "covered_area_ha": 80.0},
+            {"au_id": "au_ok", "selected_rank": 2, "covered_area_ha": 20.0},
+        ]
+    ).to_csv(selected_au_csv, index=False)
+    pd.DataFrame(
+        [
+            {"au_id": "au_bad", "age": 0, "volume": 0.0},
+            {"au_id": "au_bad", "age": 299, "volume": 12.0},
+            {"au_id": "au_ok", "age": 0, "volume": 0.0},
+            {"au_id": "au_ok", "age": 299, "volume": 450.0},
+        ]
+    ).to_csv(first_growth_curves_csv, index=False)
+    pd.DataFrame(
+        [
+            {"FEATURE_ID": 101, "PRJ_TOTAL_AGE": 350, "PRJ_VOL_DWB": 5.0},
+            {"FEATURE_ID": 102, "PRJ_TOTAL_AGE": 350, "PRJ_VOL_DWB": 420.0},
+            {"FEATURE_ID": 201, "PRJ_TOTAL_AGE": 350, "PRJ_VOL_DWB": 500.0},
+        ]
+    ).to_csv(vdyp_yields_csv, index=False)
+
+    source_table = pd.DataFrame(
+        [
+            {
+                "FOREST_COVER_ID": 101,
+                "TCL_1_ESTIMATED_SITE_INDEX": 28.0,
+                "AGE_2020": 20,
+                "BEC_ZONE_CODE": "CWH",
+                "BEC_SUBZONE": "vm",
+                "BEC_VARIANT": "1",
+            },
+            {
+                "FOREST_COVER_ID": 102,
+                "TCL_1_ESTIMATED_SITE_INDEX": 30.0,
+                "AGE_2020": 120,
+                "BEC_ZONE_CODE": "CWH",
+                "BEC_SUBZONE": "vm",
+                "BEC_VARIANT": "1",
+            },
+            {
+                "FOREST_COVER_ID": 201,
+                "TCL_1_ESTIMATED_SITE_INDEX": 32.0,
+                "AGE_2020": 110,
+                "BEC_ZONE_CODE": "CWH",
+                "BEC_SUBZONE": "dm",
+                "BEC_VARIANT": "x",
+            },
+        ]
+    )
+    monkeypatch.setattr(
+        "mkrf_femic.workflows.mkrf.gpd.read_file", lambda *args, **kwargs: source_table
+    )
+
+    result = build_mkrf_bad_curve_audit(
+        resultant_gdb=tmp_path / "resultant.gdb",
+        assignment_csv=assignment_csv,
+        selected_au_csv=selected_au_csv,
+        first_growth_curves_csv=first_growth_curves_csv,
+        vdyp_yields_csv=vdyp_yields_csv,
+        output_dir=output_dir,
+    )
+
+    summary = pd.read_csv(result.summary_path)
+    detail = pd.read_csv(result.detail_path)
+
+    assert result.flagged_au_count == 1
+    assert result.total_selected_au_count == 2
+    assert summary.loc[summary["au_id"] == "au_bad", "flagged"].item() is True
+    assert (
+        summary.loc[summary["au_id"] == "au_bad", "population_pattern"].item()
+        == "mixed_low_high"
+    )
+    assert summary.loc[summary["au_id"] == "au_bad", "age_lt_80_count"].item() == 1
+    assert summary.loc[summary["au_id"] == "au_bad", "age_gte_80_count"].item() == 1
+    assert (
+        summary.loc[summary["au_id"] == "au_bad", "curve_issue_class"].item()
+        == "mixed_population"
+    )
+    assert detail["au_id"].tolist() == ["au_bad", "au_bad"]
+    assert detail["forest_cover_id"].tolist() == [101, 102]
+
+
+def test_apply_young_skewed_sibling_borrow_replaces_only_target_curve() -> None:
+    curves = pd.DataFrame(
+        [
+            {"au_id": "cwh_dm_x_dr_cw", "age": 1, "volume": 1.0},
+            {"au_id": "cwh_dm_x_dr_cw", "age": 299, "volume": 8.0},
+            {"au_id": "cwh_dm_x_cw_dr", "age": 1, "volume": 1.0},
+            {"au_id": "cwh_dm_x_cw_dr", "age": 299, "volume": 170.0},
+        ]
+    )
+    diagnostics = pd.DataFrame(
+        [
+            {
+                "au_id": "cwh_dm_x_dr_cw",
+                "source_stand_count": 10,
+                "selected_path": "primary_nlls",
+                "accepted": True,
+            },
+            {
+                "au_id": "cwh_dm_x_cw_dr",
+                "source_stand_count": 10,
+                "selected_path": "primary_nlls",
+                "accepted": True,
+            },
+        ]
+    )
+    assignment = pd.DataFrame(
+        [
+            {
+                "res_key": 1,
+                "forest_cover_id": 101,
+                "au_id": "cwh_dm_x_dr_cw",
+                "shape_area_ha": 1.0,
+            },
+            {
+                "res_key": 2,
+                "forest_cover_id": 201,
+                "au_id": "cwh_dm_x_cw_dr",
+                "shape_area_ha": 1.0,
+            },
+            {
+                "res_key": 3,
+                "forest_cover_id": 202,
+                "au_id": "cwh_dm_x_cw_dr",
+                "shape_area_ha": 1.0,
+            },
+        ]
+    )
+    source_table = pd.DataFrame(
+        [
+            {"FOREST_COVER_ID": 101, "AGE_2020": 49},
+            {"FOREST_COVER_ID": 201, "AGE_2020": 110},
+            {"FOREST_COVER_ID": 202, "AGE_2020": 120},
+        ]
+    )
+
+    updated_curves, updated_diagnostics = _apply_young_skewed_sibling_borrow(
+        curves=curves,
+        diagnostics=diagnostics,
+        assignment=assignment,
+        source_table=source_table,
+    )
+
+    borrowed_terminal = (
+        updated_curves.loc[updated_curves["au_id"] == "cwh_dm_x_dr_cw"]
+        .sort_values("age", kind="stable")
+        .iloc[-1]["volume"]
+    )
+    assert borrowed_terminal == 170.0
+    row = updated_diagnostics.loc[
+        updated_diagnostics["au_id"] == "cwh_dm_x_dr_cw"
+    ].iloc[0]
+    assert row["selected_path"] == "borrowed_young_skewed_sibling"
+    assert row["borrowed_from_au_id"] == "cwh_dm_x_cw_dr"
+
+
+def test_apply_insufficient_support_merge_uses_largest_same_bec_neighbor() -> None:
+    curves = pd.DataFrame(
+        [
+            {"au_id": "cwh_vm_1_hw_cw", "age": 1, "volume": 1.0},
+            {"au_id": "cwh_vm_1_hw_cw", "age": 299, "volume": 260.0},
+            {"au_id": "cwh_vm_1_cw_hw", "age": 1, "volume": 1.0},
+            {"au_id": "cwh_vm_1_cw_hw", "age": 299, "volume": 180.0},
+        ]
+    )
+    diagnostics = pd.DataFrame(
+        [
+            {
+                "au_id": "cwh_vm_1_fdc_cw",
+                "source_stand_count": 1,
+                "selected_path": "insufficient_source_stands",
+                "accepted": False,
+            },
+            {
+                "au_id": "cwh_vm_1_hw_cw",
+                "source_stand_count": 10,
+                "selected_path": "primary_nlls",
+                "accepted": True,
+            },
+            {
+                "au_id": "cwh_vm_1_cw_hw",
+                "source_stand_count": 8,
+                "selected_path": "primary_nlls",
+                "accepted": True,
+            },
+        ]
+    )
+    assignment = pd.DataFrame(
+        [
+            {
+                "res_key": 1,
+                "forest_cover_id": 101,
+                "au_id": "cwh_vm_1_fdc_cw",
+                "shape_area_ha": 10.0,
+            },
+            {
+                "res_key": 2,
+                "forest_cover_id": 201,
+                "au_id": "cwh_vm_1_hw_cw",
+                "shape_area_ha": 50.0,
+            },
+            {
+                "res_key": 3,
+                "forest_cover_id": 202,
+                "au_id": "cwh_vm_1_hw_cw",
+                "shape_area_ha": 50.0,
+            },
+            {
+                "res_key": 4,
+                "forest_cover_id": 301,
+                "au_id": "cwh_vm_1_cw_hw",
+                "shape_area_ha": 20.0,
+            },
+        ]
+    )
+
+    updated_curves, updated_diagnostics = _apply_insufficient_support_merge(
+        curves=curves,
+        diagnostics=diagnostics,
+        assignment=assignment,
+        source_table=pd.DataFrame(
+            [
+                {"FOREST_COVER_ID": 101, "AGE_2020": 90},
+                {"FOREST_COVER_ID": 201, "AGE_2020": 120},
+                {"FOREST_COVER_ID": 202, "AGE_2020": 130},
+                {"FOREST_COVER_ID": 301, "AGE_2020": 110},
+            ]
+        ),
+    )
+
+    borrowed_terminal = (
+        updated_curves.loc[updated_curves["au_id"] == "cwh_vm_1_fdc_cw"]
+        .sort_values("age", kind="stable")
+        .iloc[-1]["volume"]
+    )
+    assert borrowed_terminal == 260.0
+    row = updated_diagnostics.loc[
+        updated_diagnostics["au_id"] == "cwh_vm_1_fdc_cw"
+    ].iloc[0]
+    assert row["selected_path"] == "borrowed_insufficient_support_neighbor"
+    assert row["borrowed_from_au_id"] == "cwh_vm_1_hw_cw"
+
+
+def test_apply_insufficient_support_merge_handles_missing_curve_targets() -> None:
+    curves = pd.DataFrame(
+        [
+            {"au_id": "cwh_vm_2_fdc_cw", "age": 1, "volume": 1.0},
+            {"au_id": "cwh_vm_2_fdc_cw", "age": 299, "volume": 200.0},
+        ]
+    )
+    diagnostics = pd.DataFrame(
+        [
+            {
+                "au_id": "cwh_vm_2_fdc_cw",
+                "source_stand_count": 10,
+                "selected_path": "primary_nlls",
+                "accepted": True,
+            }
+        ]
+    )
+    assignment = pd.DataFrame(
+        [
+            {
+                "res_key": 1,
+                "forest_cover_id": 101,
+                "au_id": "cwh_vm_2_cw_fdc",
+                "shape_area_ha": 10.0,
+            },
+            {
+                "res_key": 2,
+                "forest_cover_id": 201,
+                "au_id": "cwh_vm_2_fdc_cw",
+                "shape_area_ha": 50.0,
+            },
+            {
+                "res_key": 3,
+                "forest_cover_id": 202,
+                "au_id": "cwh_vm_2_fdc_cw",
+                "shape_area_ha": 50.0,
+            },
+        ]
+    )
+    source_table = pd.DataFrame(
+        [
+            {"FOREST_COVER_ID": 101, "AGE_2020": 90},
+            {"FOREST_COVER_ID": 201, "AGE_2020": 120},
+            {"FOREST_COVER_ID": 202, "AGE_2020": 130},
+        ]
+    )
+
+    updated_curves, updated_diagnostics = _apply_insufficient_support_merge(
+        curves=curves,
+        diagnostics=diagnostics,
+        assignment=assignment,
+        source_table=source_table,
+    )
+
+    borrowed_terminal = (
+        updated_curves.loc[updated_curves["au_id"] == "cwh_vm_2_cw_fdc"]
+        .sort_values("age", kind="stable")
+        .iloc[-1]["volume"]
+    )
+    assert borrowed_terminal == 200.0
+    row = updated_diagnostics.loc[
+        updated_diagnostics["au_id"] == "cwh_vm_2_cw_fdc"
+    ].iloc[0]
+    assert row["selected_path"] == "borrowed_insufficient_support_neighbor"
+    assert row["borrowed_from_au_id"] == "cwh_vm_2_fdc_cw"
+
+
+def test_apply_insufficient_support_merge_uses_fragment_level_old_support() -> None:
+    curves = pd.DataFrame(
+        [
+            {"au_id": "cwh_vm_2_fdc_cw", "age": 1, "volume": 1.0},
+            {"au_id": "cwh_vm_2_fdc_cw", "age": 299, "volume": 220.0},
+        ]
+    )
+    diagnostics = pd.DataFrame(
+        [
+            {
+                "au_id": "cwh_vm_2_fdc_cw",
+                "source_stand_count": 10,
+                "selected_path": "primary_nlls",
+                "accepted": True,
+            }
+        ]
+    )
+    assignment = pd.DataFrame(
+        [
+            {
+                "res_key": 1,
+                "forest_cover_id": 101,
+                "au_id": "cwh_vm_2_cw_fdc",
+                "shape_area_ha": 1.0,
+            },
+            {
+                "res_key": 2,
+                "forest_cover_id": 101,
+                "au_id": "cwh_vm_2_fdc_cw",
+                "shape_area_ha": 9.0,
+            },
+            {
+                "res_key": 3,
+                "forest_cover_id": 201,
+                "au_id": "cwh_vm_2_fdc_cw",
+                "shape_area_ha": 50.0,
+            },
+        ]
+    )
+    source_table = pd.DataFrame(
+        [
+            {"FOREST_COVER_ID": 101, "AGE_2020": 90},
+            {"FOREST_COVER_ID": 201, "AGE_2020": 120},
+        ]
+    )
+
+    updated_curves, updated_diagnostics = _apply_insufficient_support_merge(
+        curves=curves,
+        diagnostics=diagnostics,
+        assignment=assignment,
+        source_table=source_table,
+    )
+
+    borrowed_terminal = (
+        updated_curves.loc[updated_curves["au_id"] == "cwh_vm_2_cw_fdc"]
+        .sort_values("age", kind="stable")
+        .iloc[-1]["volume"]
+    )
+    assert borrowed_terminal == 220.0
+    row = updated_diagnostics.loc[
+        updated_diagnostics["au_id"] == "cwh_vm_2_cw_fdc"
+    ].iloc[0]
+    assert row["selected_path"] == "borrowed_insufficient_support_neighbor"
+    assert row["borrowed_from_au_id"] == "cwh_vm_2_fdc_cw"
+
+
+def test_apply_insufficient_support_merge_skips_low_terminal_donors() -> None:
+    curves = pd.DataFrame(
+        [
+            {"au_id": "cwh_dm_x_dr_ep", "age": 1, "volume": 0.000001},
+            {"au_id": "cwh_dm_x_dr_ep", "age": 299, "volume": 1.3},
+            {"au_id": "cwh_dm_x_cw_dr", "age": 1, "volume": 1.0},
+            {"au_id": "cwh_dm_x_cw_dr", "age": 299, "volume": 241.4},
+        ]
+    )
+    diagnostics = pd.DataFrame(
+        [
+            {
+                "au_id": "cwh_dm_x_dr_ep",
+                "source_stand_count": 8,
+                "selected_path": "primary_nlls",
+                "accepted": True,
+            },
+            {
+                "au_id": "cwh_dm_x_cw_dr",
+                "source_stand_count": 12,
+                "selected_path": "primary_nlls",
+                "accepted": True,
+            },
+        ]
+    )
+    assignment = pd.DataFrame(
+        [
+            {
+                "res_key": 1,
+                "forest_cover_id": 101,
+                "au_id": "cwh_dm_x_dr_mb",
+                "shape_area_ha": 1.0,
+            },
+            {
+                "res_key": 2,
+                "forest_cover_id": 201,
+                "au_id": "cwh_dm_x_dr_ep",
+                "shape_area_ha": 100.0,
+            },
+            {
+                "res_key": 3,
+                "forest_cover_id": 301,
+                "au_id": "cwh_dm_x_cw_dr",
+                "shape_area_ha": 50.0,
+            },
+        ]
+    )
+    source_table = pd.DataFrame(
+        [
+            {"FOREST_COVER_ID": 101, "AGE_2020": 84},
+            {"FOREST_COVER_ID": 201, "AGE_2020": 120},
+            {"FOREST_COVER_ID": 301, "AGE_2020": 120},
+        ]
+    )
+
+    updated_curves, updated_diagnostics = _apply_insufficient_support_merge(
+        curves=curves,
+        diagnostics=diagnostics,
+        assignment=assignment,
+        source_table=source_table,
+    )
+
+    borrowed_terminal = (
+        updated_curves.loc[updated_curves["au_id"] == "cwh_dm_x_dr_mb"]
+        .sort_values("age", kind="stable")
+        .iloc[-1]["volume"]
+    )
+    assert borrowed_terminal == 241.4
+    row = updated_diagnostics.loc[
+        updated_diagnostics["au_id"] == "cwh_dm_x_dr_mb"
+    ].iloc[0]
+    assert row["selected_path"] == "borrowed_insufficient_support_neighbor"
+    assert row["borrowed_from_au_id"] == "cwh_dm_x_cw_dr"
+
+
+def test_build_mkrf_bad_curve_audit_classifies_insufficient_source_stands(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    assignment_csv = tmp_path / "stand_au_assignment.csv"
+    selected_au_csv = tmp_path / "selected_au_table.csv"
+    first_growth_curves_csv = tmp_path / "first_growth_au_curves.csv"
+    vdyp_yields_csv = tmp_path / "vdyp_yields.csv"
+    output_dir = tmp_path / "out"
+
+    pd.DataFrame(
+        [
+            {
+                "res_key": 1,
+                "forest_cover_id": 101,
+                "shape_area_ha": 10.0,
+                "au_id": "au_sparse",
+            }
+        ]
+    ).to_csv(assignment_csv, index=False)
+    pd.DataFrame(
+        [{"au_id": "au_sparse", "selected_rank": 1, "covered_area_ha": 80.0}]
+    ).to_csv(selected_au_csv, index=False)
+    pd.DataFrame(columns=["au_id", "age", "volume"]).to_csv(
+        first_growth_curves_csv, index=False
+    )
+    pd.DataFrame(
+        [{"FEATURE_ID": 101, "PRJ_TOTAL_AGE": 350, "PRJ_VOL_DWB": 250.0}]
+    ).to_csv(vdyp_yields_csv, index=False)
+
+    source_table = pd.DataFrame(
+        [
+            {
+                "FOREST_COVER_ID": 101,
+                "TCL_1_ESTIMATED_SITE_INDEX": 28.0,
+                "AGE_2020": 90,
+                "BEC_ZONE_CODE": "CWH",
+                "BEC_SUBZONE": "vm",
+                "BEC_VARIANT": "1",
+            }
+        ]
+    )
+    monkeypatch.setattr(
+        "mkrf_femic.workflows.mkrf.gpd.read_file", lambda *args, **kwargs: source_table
+    )
+
+    result = build_mkrf_bad_curve_audit(
+        resultant_gdb=tmp_path / "resultant.gdb",
+        assignment_csv=assignment_csv,
+        selected_au_csv=selected_au_csv,
+        first_growth_curves_csv=first_growth_curves_csv,
+        vdyp_yields_csv=vdyp_yields_csv,
+        output_dir=output_dir,
+    )
+
+    summary = pd.read_csv(result.summary_path)
+    assert (
+        summary.loc[summary["au_id"] == "au_sparse", "curve_issue_class"].item()
+        == "insufficient_source_stands"
+    )
+    assert (
+        summary.loc[summary["au_id"] == "au_sparse", "old_support_stand_count"].item()
+        == 1
+    )
+
+
+def test_build_mkrf_bad_curve_audit_uses_unique_old_support_stands(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    assignment_csv = tmp_path / "stand_au_assignment.csv"
+    selected_au_csv = tmp_path / "selected_au_table.csv"
+    first_growth_curves_csv = tmp_path / "first_growth_au_curves.csv"
+    vdyp_yields_csv = tmp_path / "vdyp_yields.csv"
+    output_dir = tmp_path / "out"
+
+    pd.DataFrame(
+        [
+            {
+                "res_key": 1,
+                "forest_cover_id": 101,
+                "shape_area_ha": 10.0,
+                "au_id": "au_dup",
+            },
+            {
+                "res_key": 2,
+                "forest_cover_id": 101,
+                "shape_area_ha": 5.0,
+                "au_id": "au_dup",
+            },
+            {
+                "res_key": 3,
+                "forest_cover_id": 102,
+                "shape_area_ha": 5.0,
+                "au_id": "au_dup",
+            },
+        ]
+    ).to_csv(assignment_csv, index=False)
+    pd.DataFrame(
+        [{"au_id": "au_dup", "selected_rank": 1, "covered_area_ha": 20.0}]
+    ).to_csv(selected_au_csv, index=False)
+    pd.DataFrame(columns=["au_id", "age", "volume"]).to_csv(
+        first_growth_curves_csv, index=False
+    )
+    pd.DataFrame(
+        [
+            {"FEATURE_ID": 101, "PRJ_TOTAL_AGE": 350, "PRJ_VOL_DWB": 250.0},
+            {"FEATURE_ID": 102, "PRJ_TOTAL_AGE": 350, "PRJ_VOL_DWB": 260.0},
+        ]
+    ).to_csv(vdyp_yields_csv, index=False)
+
+    source_table = pd.DataFrame(
+        [
+            {
+                "FOREST_COVER_ID": 101,
+                "TCL_1_ESTIMATED_SITE_INDEX": 28.0,
+                "AGE_2020": 90,
+                "BEC_ZONE_CODE": "CWH",
+                "BEC_SUBZONE": "vm",
+                "BEC_VARIANT": "1",
+            },
+            {
+                "FOREST_COVER_ID": 102,
+                "TCL_1_ESTIMATED_SITE_INDEX": 30.0,
+                "AGE_2020": 40,
+                "BEC_ZONE_CODE": "CWH",
+                "BEC_SUBZONE": "vm",
+                "BEC_VARIANT": "1",
+            },
+        ]
+    )
+    monkeypatch.setattr(
+        "mkrf_femic.workflows.mkrf.gpd.read_file", lambda *args, **kwargs: source_table
+    )
+
+    result = build_mkrf_bad_curve_audit(
+        resultant_gdb=tmp_path / "resultant.gdb",
+        assignment_csv=assignment_csv,
+        selected_au_csv=selected_au_csv,
+        first_growth_curves_csv=first_growth_curves_csv,
+        vdyp_yields_csv=vdyp_yields_csv,
+        output_dir=output_dir,
+    )
+
+    summary = pd.read_csv(result.summary_path)
+    row = summary.loc[summary["au_id"] == "au_dup"].iloc[0]
+    assert row["age_gte_80_count"] == 2
+    assert row["old_support_stand_count"] == 1
+    assert row["curve_issue_class"] == "insufficient_source_stands"
+
+
+def test_build_mkrf_bad_curve_audit_reclassifies_zero_old_support_units_as_managed_only(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    assignment_csv = tmp_path / "stand_au_assignment.csv"
+    selected_au_csv = tmp_path / "selected_au_table.csv"
+    first_growth_curves_csv = tmp_path / "first_growth_au_curves.csv"
+    vdyp_yields_csv = tmp_path / "vdyp_yields.csv"
+    output_dir = tmp_path / "out"
+
+    pd.DataFrame(
+        [
+            {
+                "res_key": 1,
+                "forest_cover_id": 101,
+                "shape_area_ha": 10.0,
+                "au_id": "au_logging",
+            },
+            {
+                "res_key": 2,
+                "forest_cover_id": 102,
+                "shape_area_ha": 12.0,
+                "au_id": "au_logging",
+            },
+        ]
+    ).to_csv(assignment_csv, index=False)
+    pd.DataFrame(
+        [{"au_id": "au_logging", "selected_rank": 1, "covered_area_ha": 80.0}]
+    ).to_csv(selected_au_csv, index=False)
+    pd.DataFrame(columns=["au_id", "age", "volume"]).to_csv(
+        first_growth_curves_csv, index=False
+    )
+    pd.DataFrame(
+        [
+            {"FEATURE_ID": 101, "PRJ_TOTAL_AGE": 350, "PRJ_VOL_DWB": 225.0},
+            {"FEATURE_ID": 102, "PRJ_TOTAL_AGE": 350, "PRJ_VOL_DWB": 315.0},
+        ]
+    ).to_csv(vdyp_yields_csv, index=False)
+
+    source_table = pd.DataFrame(
+        [
+            {
+                "FOREST_COVER_ID": 101,
+                "TCL_1_ESTIMATED_SITE_INDEX": 24.0,
+                "AGE_2020": 40,
+                "BEC_ZONE_CODE": "CWH",
+                "BEC_SUBZONE": "dm",
+                "BEC_VARIANT": "x",
+            },
+            {
+                "FOREST_COVER_ID": 102,
+                "TCL_1_ESTIMATED_SITE_INDEX": 28.0,
+                "AGE_2020": 59,
+                "BEC_ZONE_CODE": "CWH",
+                "BEC_SUBZONE": "dm",
+                "BEC_VARIANT": "x",
+            },
+        ]
+    )
+    monkeypatch.setattr(
+        "mkrf_femic.workflows.mkrf.gpd.read_file", lambda *args, **kwargs: source_table
+    )
+
+    result = build_mkrf_bad_curve_audit(
+        resultant_gdb=tmp_path / "resultant.gdb",
+        assignment_csv=assignment_csv,
+        selected_au_csv=selected_au_csv,
+        first_growth_curves_csv=first_growth_curves_csv,
+        vdyp_yields_csv=vdyp_yields_csv,
+        output_dir=output_dir,
+    )
+
+    summary = pd.read_csv(result.summary_path)
+    row = summary.loc[summary["au_id"] == "au_logging"].iloc[0]
+    assert row["age_gte_80_count"] == 0
+    assert row["curve_issue_class"] == "managed_only_after_age_floor"
+    assert bool(row["flagged"]) is False

--- a/tests/test_mkrf_first_growth.py
+++ b/tests/test_mkrf_first_growth.py
@@ -1,0 +1,335 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from mkrf_femic.pipeline.mkrf_first_growth import (
+    build_mkrf_first_growth_curves,
+    collapse_stand_assignments,
+)
+from mkrf_femic.workflows.mkrf import _format_mkrf_au_label
+
+
+def test_collapse_stand_assignments_uses_area_and_lexical_tie_break() -> None:
+    assignment = pd.DataFrame(
+        [
+            {
+                "res_key": 1,
+                "forest_cover_id": 100,
+                "au_id": "cwh_vm_2_hw_cw",
+                "shape_area_ha": 3.0,
+            },
+            {
+                "res_key": 2,
+                "forest_cover_id": 100,
+                "au_id": "cwh_vm_2_cw_hw",
+                "shape_area_ha": 3.0,
+            },
+            {
+                "res_key": 3,
+                "forest_cover_id": 101,
+                "au_id": "cwh_vm_2_hw_cw",
+                "shape_area_ha": 4.0,
+            },
+            {
+                "res_key": 4,
+                "forest_cover_id": 101,
+                "au_id": "cwh_vm_2_cw_hw",
+                "shape_area_ha": 2.0,
+            },
+        ]
+    )
+
+    collapsed = collapse_stand_assignments(assignment)
+
+    row_100 = collapsed.loc[collapsed["forest_cover_id"] == 100].iloc[0]
+    assert row_100["au_id"] == "cwh_vm_2_cw_hw"
+    assert bool(row_100["tie_break_used"]) is True
+    assert row_100["assignment_weight_basis"] == "shape_area_ha"
+
+    row_101 = collapsed.loc[collapsed["forest_cover_id"] == 101].iloc[0]
+    assert row_101["au_id"] == "cwh_vm_2_hw_cw"
+    assert np.isclose(float(row_101["weight_share"]), 4.0 / 6.0)
+
+
+def test_build_mkrf_first_growth_curves_groups_stands_by_au() -> None:
+    assignment = pd.DataFrame(
+        [
+            {
+                "res_key": 1,
+                "forest_cover_id": 10,
+                "au_id": "cwh_vm_2_hw_cw",
+                "shape_area_ha": 2.0,
+            },
+            {
+                "res_key": 2,
+                "forest_cover_id": 10,
+                "au_id": "cwh_vm_2_hw_cw",
+                "shape_area_ha": 1.0,
+            },
+            {
+                "res_key": 3,
+                "forest_cover_id": 11,
+                "au_id": "cwh_vm_2_hw_cw",
+                "shape_area_ha": 1.0,
+            },
+            {
+                "res_key": 4,
+                "forest_cover_id": 12,
+                "au_id": "cwh_dm_x_act_dr",
+                "shape_area_ha": 1.0,
+            },
+        ]
+    )
+    vdyp_yields = pd.DataFrame(
+        [
+            {"FEATURE_ID": 10, "PRJ_TOTAL_AGE": 0, "PRJ_VOL_DWB": 5.0},
+            {"FEATURE_ID": 10, "PRJ_TOTAL_AGE": 50, "PRJ_VOL_DWB": 35.0},
+            {"FEATURE_ID": 10, "PRJ_TOTAL_AGE": 100, "PRJ_VOL_DWB": 70.0},
+            {"FEATURE_ID": 10, "PRJ_TOTAL_AGE": 150, "PRJ_VOL_DWB": 90.0},
+            {"FEATURE_ID": 11, "PRJ_TOTAL_AGE": 0, "PRJ_VOL_DWB": 8.0},
+            {"FEATURE_ID": 11, "PRJ_TOTAL_AGE": 50, "PRJ_VOL_DWB": 40.0},
+            {"FEATURE_ID": 11, "PRJ_TOTAL_AGE": 100, "PRJ_VOL_DWB": 80.0},
+            {"FEATURE_ID": 11, "PRJ_TOTAL_AGE": 150, "PRJ_VOL_DWB": 95.0},
+            {"FEATURE_ID": 12, "PRJ_TOTAL_AGE": 0, "PRJ_VOL_DWB": 3.0},
+            {"FEATURE_ID": 12, "PRJ_TOTAL_AGE": 50, "PRJ_VOL_DWB": 25.0},
+            {"FEATURE_ID": 12, "PRJ_TOTAL_AGE": 100, "PRJ_VOL_DWB": 60.0},
+            {"FEATURE_ID": 12, "PRJ_TOTAL_AGE": 150, "PRJ_VOL_DWB": 70.0},
+        ]
+    )
+
+    curves, diagnostics = build_mkrf_first_growth_curves(
+        vdyp_yields=vdyp_yields,
+        assignment=assignment,
+        min_source_stands=1,
+    )
+
+    assert sorted(curves["au_id"].unique().tolist()) == [
+        "cwh_dm_x_act_dr",
+        "cwh_vm_2_hw_cw",
+    ]
+    assert len(diagnostics) == 2
+
+    hw_cw = diagnostics.loc[diagnostics["au_id"] == "cwh_vm_2_hw_cw"].iloc[0]
+    assert int(hw_cw["source_stand_count"]) == 2
+    assert int(hw_cw["ambiguous_stand_count"]) == 0
+    assert hw_cw["selected_path"] == "smoothed_bin_pchip"
+    assert bool(hw_cw["accepted"]) is True
+
+
+def test_build_mkrf_first_growth_curves_lexmatches_unmatched_stands() -> None:
+    assignment = pd.DataFrame(
+        [
+            {
+                "res_key": 1,
+                "forest_cover_id": 10,
+                "au_id": "cwh_vm_1_cw_hw",
+                "bec": "CWHvm1",
+                "bec_zone": "cwh",
+                "bec_subzone": "vm",
+                "bec_variant": "1",
+                "leading_species_1": "cw",
+                "leading_species_2": "hw",
+                "leading_species_1_share": 60.0,
+                "leading_species_2_share": 40.0,
+                "species_count": 2,
+                "tie_break_used": False,
+                "shape_area_ha": 5.0,
+            }
+        ]
+    )
+    source_table = pd.DataFrame(
+        [
+            {
+                "RES_KEY": 101,
+                "FOREST_COVER_ID": 99,
+                "CONTCLAS": "X",
+                "BEC": "CWHvm1",
+                "Shape_Area": 12000.0,
+                "TCL_1_TSP_1_TREE_SPECIES_CODE": "cw",
+                "TCL_1_TSP_1_SPECIES_PCT": 60.0,
+                "TCL_1_TSP_2_TREE_SPECIES_CODE": "dr",
+                "TCL_1_TSP_2_SPECIES_PCT": 30.0,
+                "TCL_1_TSP_3_TREE_SPECIES_CODE": "hw",
+                "TCL_1_TSP_3_SPECIES_PCT": 10.0,
+            }
+        ]
+    )
+    vdyp_yields = pd.DataFrame(
+        [
+            {"FEATURE_ID": 10, "PRJ_TOTAL_AGE": 0, "PRJ_VOL_DWB": 5.0},
+            {"FEATURE_ID": 10, "PRJ_TOTAL_AGE": 50, "PRJ_VOL_DWB": 35.0},
+            {"FEATURE_ID": 10, "PRJ_TOTAL_AGE": 100, "PRJ_VOL_DWB": 70.0},
+            {"FEATURE_ID": 10, "PRJ_TOTAL_AGE": 150, "PRJ_VOL_DWB": 90.0},
+            {"FEATURE_ID": 99, "PRJ_TOTAL_AGE": 0, "PRJ_VOL_DWB": 3.0},
+            {"FEATURE_ID": 99, "PRJ_TOTAL_AGE": 50, "PRJ_VOL_DWB": 30.0},
+            {"FEATURE_ID": 99, "PRJ_TOTAL_AGE": 100, "PRJ_VOL_DWB": 60.0},
+            {"FEATURE_ID": 99, "PRJ_TOTAL_AGE": 150, "PRJ_VOL_DWB": 80.0},
+        ]
+    )
+
+    curves, diagnostics = build_mkrf_first_growth_curves(
+        vdyp_yields=vdyp_yields,
+        assignment=assignment,
+        source_table=source_table,
+        levenshtein_fn=lambda a, b: 0 if a == b else 1,
+        min_source_stands=1,
+    )
+
+    assert curves["au_id"].unique().tolist() == ["cwh_vm_1_cw_hw"]
+    row = diagnostics.iloc[0]
+    assert int(row["source_stand_count"]) == 2
+    assert int(row["lexmatch_stand_count"]) == 1
+    assert int(row["lexmatch_alias_stand_count"]) == 1
+
+
+def test_build_mkrf_first_growth_curves_excludes_stands_younger_than_80() -> None:
+    assignment = pd.DataFrame(
+        [
+            {
+                "res_key": 1,
+                "forest_cover_id": 10,
+                "au_id": "cwh_vm_1_cw_fdc",
+                "shape_area_ha": 2.0,
+            },
+            {
+                "res_key": 2,
+                "forest_cover_id": 11,
+                "au_id": "cwh_vm_1_cw_fdc",
+                "shape_area_ha": 2.0,
+            },
+        ]
+    )
+    source_table = pd.DataFrame(
+        [
+            {"FOREST_COVER_ID": 10, "AGE_2020": 40},
+            {"FOREST_COVER_ID": 11, "AGE_2020": 120},
+        ]
+    )
+    vdyp_yields = pd.DataFrame(
+        [
+            {"FEATURE_ID": 10, "PRJ_TOTAL_AGE": 0, "PRJ_VOL_DWB": 5.0},
+            {"FEATURE_ID": 10, "PRJ_TOTAL_AGE": 50, "PRJ_VOL_DWB": 35.0},
+            {"FEATURE_ID": 10, "PRJ_TOTAL_AGE": 100, "PRJ_VOL_DWB": 70.0},
+            {"FEATURE_ID": 11, "PRJ_TOTAL_AGE": 0, "PRJ_VOL_DWB": 8.0},
+            {"FEATURE_ID": 11, "PRJ_TOTAL_AGE": 50, "PRJ_VOL_DWB": 40.0},
+            {"FEATURE_ID": 11, "PRJ_TOTAL_AGE": 100, "PRJ_VOL_DWB": 80.0},
+        ]
+    )
+
+    curves, diagnostics = build_mkrf_first_growth_curves(
+        vdyp_yields=vdyp_yields,
+        assignment=assignment,
+        source_table=source_table,
+        min_source_stands=1,
+    )
+
+    assert curves["au_id"].unique().tolist() == ["cwh_vm_1_cw_fdc"]
+    row = diagnostics.iloc[0]
+    assert int(row["source_stand_count"]) == 1
+
+
+def test_build_mkrf_first_growth_curves_rejects_single_old_stand_support() -> None:
+    assignment = pd.DataFrame(
+        [
+            {
+                "res_key": 1,
+                "forest_cover_id": 10,
+                "au_id": "cwh_vm_1_dr_hw",
+                "shape_area_ha": 1.0,
+            },
+            {
+                "res_key": 2,
+                "forest_cover_id": 11,
+                "au_id": "cwh_vm_1_dr_hw",
+                "shape_area_ha": 1.0,
+            },
+        ]
+    )
+    source_table = pd.DataFrame(
+        [
+            {"FOREST_COVER_ID": 10, "AGE_2020": 79},
+            {"FOREST_COVER_ID": 11, "AGE_2020": 84},
+        ]
+    )
+    vdyp_yields = pd.DataFrame(
+        [
+            {"FEATURE_ID": 10, "PRJ_TOTAL_AGE": 50, "PRJ_VOL_DWB": 180.0},
+            {"FEATURE_ID": 10, "PRJ_TOTAL_AGE": 100, "PRJ_VOL_DWB": 240.0},
+            {"FEATURE_ID": 11, "PRJ_TOTAL_AGE": 50, "PRJ_VOL_DWB": 210.0},
+            {"FEATURE_ID": 11, "PRJ_TOTAL_AGE": 100, "PRJ_VOL_DWB": 280.0},
+        ]
+    )
+
+    curves, diagnostics = build_mkrf_first_growth_curves(
+        vdyp_yields=vdyp_yields,
+        assignment=assignment,
+        source_table=source_table,
+    )
+
+    assert curves.empty
+    row = diagnostics.iloc[0]
+    assert int(row["source_stand_count"]) == 1
+    assert row["selected_path"] == "insufficient_source_stands"
+    assert bool(row["accepted"]) is False
+
+
+def test_build_mkrf_first_growth_curves_uses_smoothed_bin_pchip_curve_family() -> None:
+    assignment = pd.DataFrame(
+        [
+            {
+                "res_key": 1,
+                "forest_cover_id": 10,
+                "au_id": "cwh_vm_1_cw_hw",
+                "shape_area_ha": 1.0,
+            },
+            {
+                "res_key": 2,
+                "forest_cover_id": 11,
+                "au_id": "cwh_vm_1_cw_hw",
+                "shape_area_ha": 1.0,
+            },
+        ]
+    )
+    source_table = pd.DataFrame(
+        [
+            {"FOREST_COVER_ID": 10, "AGE_2020": 90},
+            {"FOREST_COVER_ID": 11, "AGE_2020": 95},
+        ]
+    )
+    vdyp_yields = pd.DataFrame(
+        [
+            {"FEATURE_ID": 10, "PRJ_TOTAL_AGE": 30, "PRJ_VOL_DWB": 40.0},
+            {"FEATURE_ID": 10, "PRJ_TOTAL_AGE": 80, "PRJ_VOL_DWB": 280.0},
+            {"FEATURE_ID": 10, "PRJ_TOTAL_AGE": 150, "PRJ_VOL_DWB": 360.0},
+            {"FEATURE_ID": 10, "PRJ_TOTAL_AGE": 300, "PRJ_VOL_DWB": 320.0},
+            {"FEATURE_ID": 11, "PRJ_TOTAL_AGE": 30, "PRJ_VOL_DWB": 50.0},
+            {"FEATURE_ID": 11, "PRJ_TOTAL_AGE": 80, "PRJ_VOL_DWB": 300.0},
+            {"FEATURE_ID": 11, "PRJ_TOTAL_AGE": 150, "PRJ_VOL_DWB": 380.0},
+            {"FEATURE_ID": 11, "PRJ_TOTAL_AGE": 300, "PRJ_VOL_DWB": 340.0},
+        ]
+    )
+
+    curves, diagnostics = build_mkrf_first_growth_curves(
+        vdyp_yields=vdyp_yields,
+        assignment=assignment,
+        source_table=source_table,
+    )
+
+    row = diagnostics.iloc[0]
+    assert row["selected_path"] == "smoothed_bin_pchip"
+    terminal = (
+        curves.loc[curves["au_id"] == "cwh_vm_1_cw_hw"]
+        .sort_values("age", kind="stable")
+        .iloc[-1]["volume"]
+    )
+    assert terminal > 200.0
+    mid = curves.loc[
+        (curves["au_id"] == "cwh_vm_1_cw_hw") & (curves["age"] == 150),
+        "volume",
+    ].iloc[0]
+    assert mid > 250.0
+
+
+def test_format_mkrf_au_label_uses_k3z_style_display_shape() -> None:
+    assert _format_mkrf_au_label("cwh_vm_1_cw_hw") == "CWHvm1_CW+HW"

--- a/tests/test_mkrf_freshforge.py
+++ b/tests/test_mkrf_freshforge.py
@@ -72,7 +72,7 @@ def test_pyproject_declares_mkrf_freshforge_entry_point() -> None:
     assert entry_points["mkrf"] == "mkrf_freshforge:provider_factory"
 
 
-def test_provider_execution_constructs_femic_command() -> None:
+def test_provider_execution_constructs_mkrf_femic_command() -> None:
     from freshforge.records import ExecutionContext, WorkflowNode
 
     commands: list[tuple[str, ...]] = []
@@ -100,8 +100,7 @@ def test_provider_execution_constructs_femic_command() -> None:
         (
             sys.executable,
             "-m",
-            "femic",
-            "instance",
+            "mkrf_femic",
             "mkrf-build-au-inputs",
             "--instance-root",
             ".",

--- a/tests/test_mkrf_legacy_metadata.py
+++ b/tests/test_mkrf_legacy_metadata.py
@@ -1,0 +1,1313 @@
+from __future__ import annotations
+
+import csv
+from collections import Counter
+from pathlib import Path
+import xml.etree.ElementTree as et
+
+import pytest
+import yaml
+
+
+def _skip_if_missing(*paths: Path) -> None:
+    missing = [path for path in paths if not path.exists()]
+    if missing:
+        pytest.skip(
+            "MKRF legacy review evidence is not materialized: "
+            + ", ".join(str(path) for path in missing)
+        )
+
+
+def test_mkrf_curve_library_contract_matches_review_extract() -> None:
+    extract_path = Path("metadata/mkrf_xlsm_review/curve_library.review.csv")
+    contract_path = Path("config/legacy_xml_builder/curve_library.mkrf.yaml")
+
+    _skip_if_missing(extract_path, contract_path)
+
+    rows = list(csv.reader(extract_path.open(newline="", encoding="utf-8-sig")))
+    header = rows[5]
+    active_columns = [
+        (index, value) for index, value in enumerate(header) if value.strip()
+    ]
+
+    assert active_columns == [
+        (0, "Age"),
+        (1, "zero"),
+        (2, "age"),
+        (3, "le10"),
+        (4, "lt20"),
+        (5, "gt60"),
+        (6, "lt80"),
+        (7, "gt250"),
+    ]
+
+    expected_points = {
+        curve_id: [
+            {"age": int(row[0]), "value": int(row[column_index])}
+            for row in rows[6:]
+            if column_index < len(row) and row[column_index].strip()
+        ]
+        for column_index, curve_id in active_columns[1:]
+    }
+    expected_axis = [int(row[0]) for row in rows[6:] if row and row[0].strip()]
+
+    contract = yaml.safe_load(contract_path.read_text(encoding="utf-8"))
+
+    assert contract["build_boundary"]["live_exporter_input"] is False
+    assert (
+        contract["build_boundary"]["before_curves_hook_status"]
+        == "blocked_pending_generated_fragment_acceptance"
+    )
+    assert contract["age_axis"]["observed_values"] == expected_axis
+    assert {
+        curve["curve_id"]: curve["points"] for curve in contract["curves"]
+    } == expected_points
+    assert contract["validation_contract"]["required_curve_ids"] == list(
+        expected_points.keys()
+    )
+
+
+def test_mkrf_netdown_contract_matches_complete_review_rows() -> None:
+    criteria_path = Path("metadata/mkrf_xlsm_review/ranges/netdown_criteria.review.csv")
+    names_path = Path("metadata/mkrf_xlsm_review/ranges/netdown_names.review.csv")
+    factors_path = Path("metadata/mkrf_xlsm_review/ranges/netdown_factors.review.csv")
+    contract_path = Path("config/legacy_xml_builder/netdown.mkrf.yaml")
+
+    _skip_if_missing(criteria_path, names_path, factors_path, contract_path)
+
+    criteria_rows = list(
+        csv.reader(criteria_path.open(newline="", encoding="utf-8-sig"))
+    )
+    names_rows = list(csv.reader(names_path.open(newline="", encoding="utf-8-sig")))
+    factors_rows = list(csv.reader(factors_path.open(newline="", encoding="utf-8-sig")))
+
+    assert [
+        (index, value) for index, value in enumerate(criteria_rows[0]) if value
+    ] == [
+        (4, "status"),
+        (8, "Netdown"),
+    ]
+    assert names_rows[0][0] == "feature.area.retention.total"
+
+    complete_rows = [
+        row
+        for row in criteria_rows[1:]
+        if row[0].strip() and row[4].strip() and row[8].strip()
+    ]
+    assert complete_rows == [
+        [
+            "status in managed and oper in operable",
+            "",
+            "",
+            "",
+            "unmanaged",
+            "",
+            "",
+            "",
+            "0.1",
+        ],
+        [
+            "status in managed and oper in lowoper",
+            "",
+            "",
+            "",
+            "unmanaged",
+            "",
+            "",
+            "",
+            "0.2",
+        ],
+    ]
+
+    contract = yaml.safe_load(contract_path.read_text(encoding="utf-8"))
+
+    assert contract["build_boundary"]["live_exporter_input"] is False
+    assert (
+        contract["build_boundary"]["dump_retention_status"]
+        == "blocked_pending_retention_builder_acceptance"
+    )
+    assert [
+        {
+            "selection_expression": rule["selection_expression"],
+            "reassignment": rule["reassignment"],
+            "netdown_proportion": rule["netdown_proportion"],
+            "feature_assignments": rule["feature_assignments"],
+        }
+        for rule in contract["rules"]
+    ] == [
+        {
+            "selection_expression": "status in managed and oper in operable",
+            "reassignment": {"field": "status", "value": "unmanaged"},
+            "netdown_proportion": 0.1,
+            "feature_assignments": [
+                {"feature": "feature.area.retention.total", "value": 1}
+            ],
+        },
+        {
+            "selection_expression": "status in managed and oper in lowoper",
+            "reassignment": {"field": "status", "value": "unmanaged"},
+            "netdown_proportion": 0.2,
+            "feature_assignments": [
+                {"feature": "feature.area.retention.total", "value": 1}
+            ],
+        },
+    ]
+    nonblank_factors = [
+        row[0]
+        for row in factors_rows
+        if row and row[0].strip() and all(not cell.strip() for cell in row[1:])
+    ]
+    assert nonblank_factors == ["1", "1", "1"]
+    assert contract["review_only"]["incomplete_feature_factor_rows"] == [
+        {
+            "source_range": "netdownFactors",
+            "row_offset": 3,
+            "value": 1,
+            "reason": "No matching nonblank netdownCriteria selection row is present.",
+        }
+    ]
+    assert contract["review_only"]["incomplete_netdown_factor_tail"] == {
+        "source_range": "netdownCriteria",
+        "value": 0.07,
+        "count": 85,
+        "reason": (
+            "Values appear in the Netdown column without matching selection, "
+            "reassignment, or feature-factor rows."
+        ),
+    }
+
+
+def test_mkrf_attributes_contract_classifies_review_rows() -> None:
+    extract_path = Path("metadata/mkrf_xlsm_review/ranges/attrib_attributes.review.csv")
+    contract_path = Path("config/legacy_xml_builder/attributes.mkrf.yaml")
+
+    _skip_if_missing(extract_path, contract_path)
+
+    rows = list(csv.reader(extract_path.open(newline="", encoding="utf-8-sig")))
+
+    assert rows[0][:9] == [
+        "Applies to",
+        "Curve or Expression",
+        "Attribute Name",
+        "Factor",
+        "Future",
+        "Cycle",
+        "Ignore",
+        "Output",
+        "Scale",
+    ]
+
+    complete_rows = {
+        row_offset: row
+        for row_offset, row in enumerate(rows[1:], start=1)
+        if len(row) > 2 and row[2].strip()
+    }
+    incomplete_rows = [
+        row_offset
+        for row_offset, row in enumerate(rows[1:], start=1)
+        if any(cell.strip() for cell in row) and not (len(row) > 2 and row[2].strip())
+    ]
+
+    contract = yaml.safe_load(contract_path.read_text(encoding="utf-8"))
+
+    assert contract["build_boundary"]["live_exporter_input"] is False
+    assert (
+        contract["build_boundary"]["dump_attributes_status"]
+        == "blocked_pending_attribute_builder_acceptance"
+    )
+    assert contract["row_summary"] == {
+        "complete_attribute_rows": 16,
+        "incomplete_template_rows": 143,
+        "rows_with_frd_dependency": 14,
+        "rows_with_yield_curve_dependency": 11,
+        "rows_with_lookup_table_dependency": 8,
+        "rows_with_attribute_reference_dependency": 1,
+        "rows_with_curve_library_dependency": 1,
+    }
+    assert len(complete_rows) == contract["row_summary"]["complete_attribute_rows"]
+    assert len(incomplete_rows) == contract["row_summary"]["incomplete_template_rows"]
+
+    contract_rows = {row["row_offset"]: row for row in contract["attribute_rows"]}
+    assert sorted(contract_rows) == sorted(complete_rows)
+    assert contract_rows[9]["attribute_name"] == "%f.yield.%m.merch.total"
+    assert (
+        contract_rows[9]["status"]
+        == "review_to_build_candidate_blocked_by_attribute_dependency"
+    )
+    assert contract_rows[21] == {
+        "row_offset": 21,
+        "family_id": "seral_area_le10",
+        "applies_to": "feature",
+        "curve_or_expression": "le10",
+        "attribute_name": "%f.area.%m.seral.le10",
+        "factor_expression": "1",
+        "selection_expression": "status ne 'X'",
+        "status": "review_to_build_candidate",
+    }
+
+    workbook_attribute_names = {
+        row[2].strip().strip("'") for row in complete_rows.values()
+    }
+    assert set(contract["validation_contract"]["required_attribute_names"]).issubset(
+        workbook_attribute_names
+    )
+    assert contract["review_only"]["incomplete_template_rows"]["count"] == len(
+        incomplete_rows
+    )
+
+
+def test_mkrf_treat_contract_preserves_treatments_and_review_only_rows() -> None:
+    ranges_root = Path("metadata/mkrf_xlsm_review/ranges")
+    contract_path = Path("config/legacy_xml_builder/strata/treat.mkrf.yaml")
+    treatments_path = Path("data/legacy_mkrf/compiled_tracks/treatments.csv")
+
+    _skip_if_missing(
+        ranges_root / "treat_stratum_criteria.review.csv",
+        ranges_root / "treat_stratum_succession.review.csv",
+        ranges_root / "treat_stratum_features.review.csv",
+        ranges_root / "treat_stratum_products.review.csv",
+        ranges_root / "treat_stratum_factors.review.csv",
+        contract_path,
+        treatments_path,
+    )
+
+    criteria_rows = list(
+        csv.reader(
+            (ranges_root / "treat_stratum_criteria.review.csv").open(
+                newline="", encoding="utf-8-sig"
+            )
+        )
+    )
+    succession_rows = list(
+        csv.reader(
+            (ranges_root / "treat_stratum_succession.review.csv").open(
+                newline="", encoding="utf-8-sig"
+            )
+        )
+    )
+    features_rows = list(
+        csv.reader(
+            (ranges_root / "treat_stratum_features.review.csv").open(
+                newline="", encoding="utf-8-sig"
+            )
+        )
+    )
+    products_rows = list(
+        csv.reader(
+            (ranges_root / "treat_stratum_products.review.csv").open(
+                newline="", encoding="utf-8-sig"
+            )
+        )
+    )
+    factors_rows = list(
+        csv.reader(
+            (ranges_root / "treat_stratum_factors.review.csv").open(
+                newline="", encoding="utf-8-sig"
+            )
+        )
+    )
+    treatment_rows = list(
+        csv.reader(
+            (ranges_root / "treat_stratum_treatments.review.csv").open(
+                newline="", encoding="utf-8-sig"
+            )
+        )
+    )
+
+    contract = yaml.safe_load(contract_path.read_text(encoding="utf-8"))
+
+    assert contract["build_boundary"]["live_exporter_input"] is False
+    assert (
+        contract["build_boundary"]["dump_stratum_status"]
+        == "blocked_pending_stratum_builder_acceptance"
+    )
+    assert not any(any(cell.strip() for cell in row) for row in criteria_rows)
+    assert contract["stratum"]["selection_criteria"]["status"] == "empty"
+    assert succession_rows[0][2] == "Breakup at"
+    assert succession_rows[0][9] == "Renewal age"
+    assert succession_rows[1][2] == "999"
+    assert succession_rows[1][9] == "0"
+    assert contract["stratum"]["succession"] == {
+        "status": "review_to_build_candidate_default_rule",
+        "breakup_at": 999,
+        "renewal_age": 0,
+    }
+
+    named_feature_rows = [row for row in features_rows[1:] if row[4].strip()]
+    named_product_rows = [
+        row for row in products_rows if len(row) > 2 and row[2].strip()
+    ]
+    assert named_feature_rows == []
+    assert named_product_rows == []
+    assert contract["stratum"]["feature_rows"]["named_feature_count"] == 0
+    assert contract["stratum"]["product_rows"]["named_product_count"] == 0
+    assert contract["stratum"]["feature_rows"]["row_count"] == len(features_rows) - 1
+    assert contract["stratum"]["product_rows"]["row_count"] == len(products_rows)
+
+    assert treatment_rows[0][2:4] == ["CC", "CT"]
+    assert treatment_rows[1][2:4] == ["managed", "managed"]
+    assert treatment_rows[5][2] == "if(oper in operable, 60, 150)"
+    assert treatment_rows[5][3] == "40"
+    assert treatment_rows[6][3] == "150"
+    assert treatment_rows[8][2] == "auf"
+    assert treatment_rows[8][3] == " 'thn_'+au"
+    assert treatment_rows[17][2:4] == ["0", "20"]
+    assert factors_rows[1][2:4] == ["1", "1"]
+
+    assert {treatment["treatment_id"] for treatment in contract["treatments"]} == {
+        "CC",
+        "CT",
+    }
+    ct_contract = next(
+        treatment
+        for treatment in contract["treatments"]
+        if treatment["treatment_id"] == "CT"
+    )
+    assert ct_contract["selection"]["additional_expressions"] == [
+        "oper in operable",
+        "ct eq 'Y'",
+        "not startswith(au,'t')",
+    ]
+    assert ct_contract["maximum_operable_age"] == 150
+    assert ct_contract["retention"] == 20
+
+    compiled_rows = list(
+        csv.DictReader(treatments_path.open(newline="", encoding="utf-8-sig"))
+    )
+    compiled_counts = Counter(row["TREATMENT"] for row in compiled_rows)
+    assert dict(compiled_counts) == {"CC": 1434, "CT": 590}
+    assert contract["compiled_track_crosscheck"]["treatments_csv"]["row_count"] == len(
+        compiled_rows
+    )
+    assert contract["compiled_track_crosscheck"]["treatments_csv"][
+        "treatment_counts"
+    ] == dict(compiled_counts)
+
+
+def test_mkrf_rebuild_readiness_records_no_go_contract_gaps() -> None:
+    reconciliation_path = Path("metadata/legacy_workbook_compiled_reconciliation.yaml")
+
+    if not reconciliation_path.exists():
+        pytest.skip("MKRF instance submodule is not materialized")
+
+    reconciliation = yaml.safe_load(reconciliation_path.read_text(encoding="utf-8"))
+
+    assert reconciliation["decision"] == "no_go_for_runnable_rebuild"
+    assert reconciliation["go_no_go"] == {
+        "rebuild_claim": "no_go",
+        "metadata_recovery_claim": "go",
+        "rationale": [
+            (
+                "Phase 55 recovered the workbook-owned source contract into "
+                "FEMIC-ready metadata surfaces."
+            ),
+            (
+                "The current instance is not a runnable legacy Patchworks rebuild "
+                "because generated XML fragments, builder activation, and several "
+                "compiled matrix tables remain unreconciled."
+            ),
+            (
+                "Compiled archival outputs are sufficient as review evidence for "
+                "planning the next recovery phase, not as substitute raw/source inputs."
+            ),
+        ],
+    }
+
+    pin_contract = reconciliation["compiled_output_evidence"]["pin_entrypoint"][
+        "observed_contract"
+    ]
+    assert pin_contract["horizon_years"] == 300
+    assert pin_contract["block_key"] == "RES_KEY"
+    assert pin_contract["use_routes"] is False
+    assert pin_contract["use_patches"] is True
+
+    track_tables = reconciliation["compiled_output_evidence"]["track_tables"]
+    assert track_tables["materialized_tables"]["accounts.csv"]["rows"] == 60
+    assert track_tables["materialized_tables"]["treatments.csv"]["rows"] == 2024
+    assert track_tables["materialized_tables"]["strata.csv"]["rows"] == 2116
+    assert track_tables["legacy_source_tables"] == {
+        "curves.csv": {
+            "legacy_path": (
+                "MKRF_Cosmin_Model/MKRF/04_Models/PW_MKRF/Tracks/curves.csv"
+            ),
+            "status": "legacy_source_available",
+            "size_bytes": 4767897,
+            "row_count": 283654,
+        },
+        "features.csv": {
+            "legacy_path": (
+                "MKRF_Cosmin_Model/MKRF/04_Models/PW_MKRF/Tracks/features.csv"
+            ),
+            "status": "legacy_source_available",
+            "size_bytes": 1177960,
+            "row_count": 29364,
+        },
+        "products.csv": {
+            "legacy_path": (
+                "MKRF_Cosmin_Model/MKRF/04_Models/PW_MKRF/Tracks/products.csv"
+            ),
+            "status": "legacy_source_available",
+            "size_bytes": 1321697,
+            "row_count": 28336,
+        },
+    }
+    assert track_tables["instance_pointer_only_tables"] == {
+        "curves.csv": {
+            "instance_path": "data/legacy_mkrf/compiled_tracks/curves.csv",
+            "status": "instance_pointer_only",
+            "publication_status": "requires_git_annex_for_instance_publication",
+        },
+        "features.csv": {
+            "instance_path": "data/legacy_mkrf/compiled_tracks/features.csv",
+            "status": "instance_pointer_only",
+            "publication_status": "requires_git_annex_for_instance_publication",
+        },
+        "products.csv": {
+            "instance_path": "data/legacy_mkrf/compiled_tracks/products.csv",
+            "status": "instance_pointer_only",
+            "publication_status": "requires_git_annex_for_instance_publication",
+        },
+    }
+    assert track_tables["observed_contract"]["treatments"]["treatment_counts"] == {
+        "CC": 1434,
+        "CT": 590,
+    }
+
+    generated_xml = reconciliation["compiled_output_evidence"][
+        "generated_xml_artifacts"
+    ]
+    assert generated_xml["base_mkrf_xml"]["status"] == (
+        "available_generated_review_artifact_after_p56_2"
+    )
+    assert generated_xml["curves_xml"]["status"] == (
+        "located_and_reconciled_from_legacy_path_not_copied_after_p56_2"
+    )
+    assert generated_xml["curve_table_csv"]["status"] == (
+        "available_generated_review_artifact_after_p56_2"
+    )
+    assert reconciliation["next_bounded_step"] == {
+        "recommendation": "implement_first_builder_activation_gate",
+        "roadmap_task": "future_phase",
+        "description": (
+            "Phase 56 closed with rebuild-readiness criteria published. The next phase "
+            "should implement the first selected builder activation gate before any "
+            "matrix-build execution or runnable rebuild claim."
+        ),
+    }
+
+
+def test_mkrf_generated_xml_reconciliation_records_p56_2_boundary() -> None:
+    reconciliation_path = Path("metadata/legacy_generated_xml_reconciliation.yaml")
+
+    if not reconciliation_path.exists():
+        pytest.skip("MKRF instance submodule is not materialized")
+
+    reconciliation = yaml.safe_load(reconciliation_path.read_text(encoding="utf-8"))
+
+    assert reconciliation["phase"] == "P56.2"
+    assert reconciliation["decision"] == {
+        "generated_xml_review_artifacts": (
+            "base_xml_and_curve_table_materialized_for_review"
+        ),
+        "before_curves_activation": "blocked",
+        "xml_builder_activation": "not_started",
+        "runnable_rebuild_claim": "no_go",
+    }
+
+    source_artifacts = reconciliation["source_artifacts"]
+    assert source_artifacts["base_mkrf_xml"]["instance_path"] == (
+        "data/legacy_mkrf/generated_xml/baseMKRF.xml"
+    )
+    assert source_artifacts["curves_xml"]["instance_path"] is None
+    assert source_artifacts["curves_xml"]["status"] == (
+        "located_and_reconciled_from_legacy_path_not_copied"
+    )
+    assert source_artifacts["curve_table_csv"]["instance_path"] == (
+        "data/legacy_mkrf/generated_xml/CSV/CURVE_TABLE.csv"
+    )
+
+    base_contract = reconciliation["base_mkrf_xml_contract"]
+    assert base_contract["forest_model"] == {
+        "generated_literal_description": "Base TFL26",
+        "horizon_years": 300,
+        "start_year": 2020,
+        "max_inventory_age": 350,
+        "match": "multi",
+    }
+    assert base_contract["identity_check"]["status"] == (
+        "legacy_description_mismatch_recorded"
+    )
+    assert base_contract["input"] == {
+        "block": "Int(RES_KEY)",
+        "area": "area()/10000",
+        "age": "Int(AGE_2020)",
+        "exclude": "CONTCLAS eq 'X'",
+    }
+    assert base_contract["base_curve_ids"] == [
+        "one",
+        "zero",
+        "age",
+        "le10",
+        "lt20",
+        "gt60",
+        "lt80",
+        "gt250",
+    ]
+
+    curves = reconciliation["curves_xml_reconciliation"]
+    assert curves["curve_count"] == 1049
+    assert curves["point_count"] == 37764
+    assert curves["points_per_curve"] == 36
+    assert curves["equivalence"]["status"] == "matched_by_curve_age_value_sets"
+
+    remaining_gaps = set(reconciliation["remaining_gaps"])
+    assert any("beforeCurves remains inactive" in gap for gap in remaining_gaps)
+    assert any(
+        "P56.3 verified existing legacy compiled curves/features/products" in gap
+        for gap in remaining_gaps
+    )
+    assert reconciliation["next_bounded_step"] == {
+        "recommendation": "implement_first_builder_activation_gate",
+        "roadmap_task": "future_phase",
+    }
+
+
+def test_mkrf_compiled_track_evidence_reconciliation_records_p56_3_boundary() -> None:
+    reconciliation_path = Path(
+        "metadata/legacy_compiled_track_evidence_reconciliation.yaml"
+    )
+
+    if not reconciliation_path.exists():
+        pytest.skip("MKRF instance submodule is not materialized")
+
+    reconciliation = yaml.safe_load(reconciliation_path.read_text(encoding="utf-8"))
+
+    assert reconciliation["phase"] == "P56.3"
+    assert reconciliation["decision"] == {
+        "legacy_compiled_track_evidence": "available_in_planning_corpus",
+        "instance_publication": "blocked_pending_git_annex",
+        "matrix_build": "not_run",
+        "femic_regenerated_outputs": "not_claimed",
+        "runnable_rebuild_claim": "no_go",
+    }
+    assert reconciliation["tooling_boundary"]["git_annex"] == (
+        "unavailable_in_active_shell"
+    )
+
+    source_tables = reconciliation["source_tables"]
+    assert source_tables["curves_csv"]["source_status"] == "legacy_source_available"
+    assert source_tables["curves_csv"]["instance_status"] == "instance_pointer_only"
+    assert source_tables["curves_csv"]["row_count"] == 283654
+    assert source_tables["curves_csv"]["unique_curve_count"] == 10172
+
+    assert source_tables["features_csv"]["row_count"] == 29364
+    assert source_tables["features_csv"]["unique_track_count"] == 2116
+    assert source_tables["features_csv"]["unique_label_count"] == 38
+    assert (
+        source_tables["features_csv"]["observed_key_labels"][
+            "feature.area.managed.seral.le10"
+        ]["row_count"]
+        == 1434
+    )
+
+    assert source_tables["products_csv"]["row_count"] == 28336
+    assert source_tables["products_csv"]["unique_track_count"] == 1434
+    assert source_tables["products_csv"]["treatment_row_counts"] == {
+        "CC": 20076,
+        "CT": 8260,
+    }
+    assert (
+        source_tables["products_csv"]["observed_key_labels"][
+            "product.area.managed.treat.CT"
+        ]["row_count"]
+        == 590
+    )
+
+    assert reconciliation["scope_boundary"] == [
+        "No ForestModel XML was generated.",
+        "No fragments were regenerated.",
+        "No Patchworks matrix build was run.",
+        "No compiled track payloads were imported into the instance in this slice.",
+        "No future FEMIC-regenerated track outputs are claimed.",
+        "No runnable FEMIC/Patchworks rebuild claim is introduced.",
+    ]
+    assert reconciliation["next_bounded_step"] == {
+        "recommendation": "implement_first_builder_activation_gate",
+        "roadmap_task": "future_phase",
+    }
+
+
+def test_mkrf_builder_activation_plan_records_p56_4_boundary() -> None:
+    plan_path = Path("metadata/legacy_builder_activation_plan.yaml")
+
+    if not plan_path.exists():
+        pytest.skip("MKRF instance submodule is not materialized")
+
+    plan = yaml.safe_load(plan_path.read_text(encoding="utf-8"))
+
+    assert plan["phase"] == "P56.4"
+    assert plan["decision"] == {
+        "builder_activation": "not_started",
+        "matrix_build": "not_run",
+        "default_exporter_behavior": "unchanged",
+        "mkrf_activation": "opt_in_only",
+        "runnable_rebuild_claim": "no_go",
+    }
+
+    assert [step["surface"] for step in plan["activation_order"]] == [
+        "curve_emission",
+        "retention_netdown_emission",
+        "attribute_emission",
+        "stratum_treat_emission",
+        "full_forestmodel_xml_emission",
+        "patchworks_matrix_build_handoff",
+    ]
+
+    matrix_handoff = plan["activation_order"][-1]
+    assert matrix_handoff["validation_gate"] == [
+        "Run only after source-input publication boundary is resolved.",
+        "Never treat archival legacy compiled tracks as FEMIC-generated outputs.",
+        (
+            "Compare matrix-build outputs to legacy compiled track evidence before "
+            "any runnable rebuild claim."
+        ),
+    ]
+
+    assert plan["legacy_evidence_boundary"]["rule"] == [
+        "Archival evidence may be used for comparison and acceptance gates.",
+        "Archival evidence must not be relabeled as FEMIC-regenerated output.",
+        (
+            "Matrix-build success is not sufficient without direct output comparison "
+            "against relevant legacy evidence."
+        ),
+    ]
+    assert plan["scope_boundary"] == [
+        "No builder was activated by P56.4.",
+        "No ForestModel XML was generated by P56.4.",
+        "No fragments were regenerated by P56.4.",
+        "No Patchworks matrix build was run by P56.4.",
+        "No default exporter behavior changed.",
+        "No runnable FEMIC/Patchworks rebuild claim is introduced.",
+    ]
+    assert plan["next_bounded_step"] == {
+        "recommendation": "implement_first_builder_activation_gate",
+        "roadmap_task": "future_phase",
+    }
+
+
+def test_mkrf_source_input_publication_boundary_records_p56_5_decision() -> None:
+    boundary_path = Path("metadata/legacy_source_input_publication_boundary.yaml")
+
+    if not boundary_path.exists():
+        pytest.skip("MKRF instance submodule is not materialized")
+
+    boundary = yaml.safe_load(boundary_path.read_text(encoding="utf-8"))
+
+    assert boundary["phase"] == "P56.5"
+    assert boundary["last_updated_phase"] == "P58.3b"
+    assert boundary["decision"] == {
+        "source_input_publication_boundary": "resolved_for_next_readiness_gate",
+        "payload_intake": "not_started",
+        "matrix_build": "not_run",
+        "builder_activation": "not_started",
+        "runnable_rebuild_claim": "no_go",
+    }
+
+    fragments = boundary["required_for_future_matrix_build_candidate"][
+        "compiled_runtime_inputs"
+    ]["fragments"]
+    assert (
+        fragments["publication_status"] == "requires_git_annex_for_instance_publication"
+    )
+    assert fragments["readable_legacy_source"]["feature_count"] == 1763
+    assert fragments["readable_legacy_source"]["geometry_type"] == "Polygon"
+    assert fragments["readable_legacy_source"]["crs"] == "EPSG:3005"
+    assert fragments["readable_legacy_source"]["required_fields"] == [
+        "RES_KEY",
+        "CONTCLAS",
+        "AGE_2020",
+        "AU_EX",
+        "AU_FU",
+        "Operabilit",
+        "CT_eligib",
+    ]
+
+    field_contract = boundary["field_contract"]
+    assert field_contract["base_mkrf_xml_input"] == {
+        "block": "Int(RES_KEY)",
+        "area": "area()/10000",
+        "age": "Int(AGE_2020)",
+        "exclude": "CONTCLAS eq 'X'",
+    }
+    assert field_contract["additional_stratification"]["ct"] == "CT_eligib"
+
+    lanes = boundary["publication_lanes"]
+    assert lanes["archival_runtime_candidate_lane"]["status"] == (
+        "blocked_pending_git_annex_for_fragments"
+    )
+    assert lanes["raw_source_reproducibility_lane"]["status"] == (
+        "resultant_boundary_reconstructed_and_substitute_separation_explicit"
+    )
+    reconstructed = lanes["raw_source_reproducibility_lane"][
+        "reconstructed_fragments_publication_boundary"
+    ]
+    assert reconstructed["source_feature_class"] == {
+        "path": (
+            "MKRF_Cosmin_Model/MKRF/03_MappingAnalysisData/Resultant.gdb/Resultant"
+        ),
+        "feature_count": 1873,
+        "geometry_type": "MultiPolygon",
+    }
+    assert reconstructed["runtime_publication"] == {
+        "target_glob": "MKRF_Cosmin_Model/MKRF/04_Models/PW_MKRF/Spatial/fragments.*",
+        "published_feature_count": 1763,
+        "geometry_type": "Polygon",
+        "filter": {
+            "expression": "CONTCLAS != 'X'",
+            "excluded_feature_count": 110,
+            "excluded_rollup": "2_Non_Forest",
+            "excluded_netdown_counts": {
+                "2_11_Non_Forest": 97,
+                "2_10_Roads": 13,
+            },
+        },
+    }
+    assert reconstructed["field_projection"] == [
+        {"source": "Operability", "published": "Operabilit"},
+        {"source": "Shape_Length", "published": "Shape_Leng"},
+        {"source": "Shape_Area", "published": "Shape_Area"},
+        {"source": "CONTCLAS", "published": "CONTCLAS"},
+        {"source": "AGE_2020", "published": "AGE_2020"},
+        {"source": "AU_EX", "published": "AU_EX"},
+        {"source": "AU_FU", "published": "AU_FU"},
+        {"source": "RES_KEY", "published": "RES_KEY"},
+        {"source": "CT_eligib", "published": "CT_eligib"},
+    ]
+    assert reconstructed["verification"] == {
+        "shared_res_key_count": 1763,
+        "core_field_mismatches": 0,
+        "true_multipart_shared_features": 0,
+        "note": [
+            "Resultant rows carried single-part multipolygon geometries only.",
+            ("No value drift was observed across the published runtime field subset."),
+        ],
+    }
+    assert lanes["raw_source_reproducibility_lane"]["substitute_boundary"] == {
+        "raw_source_rule": {
+            "status": "required_for_source_faithful_claim",
+            "definition": [
+                (
+                    "Raw source means the upstream "
+                    "`03_MappingAnalysisData/*` surfaces that feed "
+                    "`Resultant.gdb/Resultant`, not later published runtime "
+                    "artifacts."
+                ),
+                (
+                    "A source-faithful rebuild claim must start from those "
+                    "upstream source surfaces or a fully documented "
+                    "reproduction of them."
+                ),
+            ],
+        },
+        "compiled_runtime_substitutes": {
+            "status": "not_acceptable_as_raw_source",
+            "rejected_surfaces": [
+                "MKRF_Cosmin_Model/MKRF/04_Models/PW_MKRF/Spatial/fragments.*",
+                "MKRF_Cosmin_Model/MKRF/04_Models/PW_MKRF/Spatial/topo_frag100.csv",
+                "data/legacy_mkrf/compiled_spatial/fragments.*",
+                "data/legacy_mkrf/compiled_spatial/topo_frag100.csv",
+            ],
+            "rationale": [
+                (
+                    "These are compiled runtime publications used for "
+                    "matrix-build and launch validation, not upstream source "
+                    "inputs."
+                ),
+                (
+                    "They may serve as comparison evidence, but not as "
+                    "substitutes for source-faithful reconstruction."
+                ),
+            ],
+        },
+        "checkpoint_derived_substitutes": {
+            "status": "not_acceptable_as_raw_source",
+            "rejected_classes": [
+                "instance-local restart or resume checkpoints",
+                "exported fragments derived from previously compiled runtime lanes",
+                (
+                    "any derived boundary/checkpoint artifact created for "
+                    "debugging or restart convenience"
+                ),
+            ],
+            "rationale": [
+                (
+                    "Checkpoints are derived intermediates. They can support "
+                    "resume or debugging, but they do not answer raw-source "
+                    "provenance questions."
+                ),
+                (
+                    "P58.3 explicitly keeps checkpoint-derived artifacts "
+                    "separate from the upstream mapping and yield-prep "
+                    "source lane."
+                ),
+            ],
+        },
+    }
+    assert lanes["current_femic_run_profile_lane"]["status"] == (
+        "template_not_runnable_source_boundary"
+    )
+
+    assert boundary["explicit_non_requirements_for_next_gate"]["roads"]["status"] == (
+        "not_required_for_current_legacy_pin"
+    )
+    assert boundary["explicit_non_requirements_for_next_gate"]["outputs"]["status"] == (
+        "not_required_as_source_input"
+    )
+    assert (
+        boundary["explicit_non_requirements_for_next_gate"][
+            "direct_workbook_publication"
+        ]["status"]
+        == "not_required_for_current_femic_contract"
+    )
+
+    assert boundary["identity_boundary"] == {
+        "generated_xml_literal_description": "Base TFL26",
+        "accepted_case_identity": "mkrf_legacy_2016",
+        "status": "mismatch_recorded_not_accepted_identity",
+        "decision": [
+            "Preserve `Base TFL26` as a literal legacy artifact value.",
+            "Do not use `Base TFL26` as the MKRF case identity.",
+            (
+                "Carry the mismatch into rebuild-readiness criteria as a required "
+                "caveat or correction before any user-facing runnable claim."
+            ),
+        ],
+    }
+    assert boundary["next_bounded_step"] == {
+        "recommendation": "publish_reproducibility_boundary_before_source_faithful_claim",
+        "roadmap_task": "P58.3c",
+    }
+
+
+def test_mkrf_rebuild_readiness_criteria_close_phase_56() -> None:
+    criteria_path = Path("metadata/legacy_rebuild_readiness_criteria.yaml")
+
+    if not criteria_path.exists():
+        pytest.skip("MKRF instance submodule is not materialized")
+
+    criteria = yaml.safe_load(criteria_path.read_text(encoding="utf-8"))
+
+    assert criteria["phase"] == "P56.6"
+    assert criteria["decision"] == {
+        "metadata_recovery": "complete_for_phase_56",
+        "runnable_rebuild_candidate": "no_go",
+        "builder_activation": "not_started",
+        "matrix_build": "not_run",
+        "runnable_rebuild_claim": "blocked_until_all_criteria_pass",
+    }
+
+    assert criteria["claim_levels"]["metadata_recovery_complete"]["status"] == "go"
+    assert (
+        criteria["claim_levels"]["runnable_rebuild_candidate_ready"]["status"]
+        == "no_go"
+    )
+
+    gates = {
+        gate["gate_id"]: gate["status"] for gate in criteria["required_go_no_go_gates"]
+    }
+    assert gates == {
+        "legacy_evidence_gate": "passed_for_metadata_recovery",
+        "source_input_publication_gate": "not_passed",
+        "builder_activation_gate": "not_started",
+        "generated_xml_gate": "not_started",
+        "matrix_build_gate": "not_started",
+        "output_comparison_gate": "not_started",
+        "identity_gate": "not_passed",
+    }
+
+    assert criteria["explicit_scope_boundary"] == [
+        "No builder was activated by P56.6.",
+        "No ForestModel XML was generated by P56.6.",
+        "No fragments were regenerated by P56.6.",
+        "No Patchworks matrix build was run by P56.6.",
+        "No source payloads, roads, outputs, or direct workbook payloads were ingested by P56.6.",
+        "No runnable FEMIC/Patchworks rebuild claim is introduced.",
+    ]
+    assert criteria["phase_56_closeout"] == {
+        "status": "closed_as_readiness_planning_and_evidence_boundary_phase",
+        "next_recommended_phase": {
+            "focus": "implement_first_builder_activation_gate",
+            "starting_boundary": [
+                "Start with curve emission or another explicitly selected P56.4 gate.",
+                (
+                    "Do not run matrix build until source-input publication and "
+                    "XML emission gates pass."
+                ),
+            ],
+        },
+    }
+
+
+def test_mkrf_runtime_model_layout_records_p57_2_boundary() -> None:
+    layout_path = Path("metadata/legacy_runtime_model_layout.yaml")
+
+    if not layout_path.exists():
+        pytest.skip("MKRF instance submodule is not materialized")
+
+    layout = yaml.safe_load(layout_path.read_text(encoding="utf-8"))
+
+    assert layout["phase"] == "P57.2"
+    assert layout["status"] == "runtime_model_directory_materialized_pre_xml"
+    assert layout["decision"] == {
+        "runtime_model_directory": "materialized",
+        "accepted_runtime_input_lane": "legacy_compiled_spatial_and_controls",
+        "spatial_payload_source": "local_planning_corpus_compiled_runtime_copy",
+        "archival_annex_remote_materialization": "blocked_in_active_shell",
+        "xml_emission": "not_started",
+        "matrix_build": "not_run",
+        "launch_proof": "not_run",
+        "runnable_rebuild_claim": "no_go",
+    }
+
+    assert layout["model_layout"] == {
+        "model_root": "models/mkrf_patchworks_model_poc",
+        "analysis_root": "models/mkrf_patchworks_model_poc/analysis",
+        "xml_root": "models/mkrf_patchworks_model_poc/XML",
+        "spatial_root": "models/mkrf_patchworks_model_poc/Spatial",
+        "tracks_root": "models/mkrf_patchworks_model_poc/Tracks",
+        "scripts_root": "models/mkrf_patchworks_model_poc/Scripts",
+        "targets_root": "models/mkrf_patchworks_model_poc/Targets",
+        "initial_targets_root": "models/mkrf_patchworks_model_poc/InitialTargets",
+    }
+
+    spatial_contract = layout["materialized_inputs"]["spatial_runtime"]["contract"]
+    assert spatial_contract == {
+        "crs": "EPSG:3005",
+        "feature_count": 1763,
+        "block_key": "RES_KEY",
+    }
+    assert layout["materialized_inputs"]["scenario_controller"]["known_gap"] == [
+        (
+            "the legacy target-description file was not recovered in the compiled "
+            "control slice and is represented by a fail-fast placeholder"
+        )
+    ]
+    assert layout["future_output_staging"] == {
+        "xml_root": {
+            "path": "models/mkrf_patchworks_model_poc/XML",
+            "producer": "P57.3_femic_opt_in_mkrf_xml_emission",
+        },
+        "tracks_root": {
+            "path": "models/mkrf_patchworks_model_poc/Tracks",
+            "producer": "P57.6_patchworks_matrix_build",
+        },
+    }
+    assert layout["scope_boundary"] == [
+        "No FEMIC-generated ForestModel XML was written into the runtime model directory.",
+        "No legacy compiled track tables were copied into runtime `Tracks/` as generated output.",
+        "No Patchworks runtime config was rewired.",
+        "No Patchworks matrix build was run.",
+        "No Patchworks launch proof was run.",
+        "No runnable FEMIC/Patchworks rebuild claim is introduced.",
+    ]
+    assert layout["next_bounded_step"] == {
+        "recommendation": "implement_opt_in_mkrf_xml_emission",
+        "roadmap_task": "P57.3",
+    }
+
+    runtime_root = Path("models/mkrf_patchworks_model_poc")
+    assert (runtime_root / "analysis" / "base.pin").exists()
+    assert (runtime_root / "analysis" / "ScenarioSet.bsh").exists()
+    assert (runtime_root / "Spatial" / "fragments.shp").exists()
+    assert (runtime_root / "Spatial" / "topo_frag100.csv").exists()
+    placeholder = runtime_root / "InitialTargets" / "00_Target_Descriptions.bsh"
+    assert placeholder.exists()
+    placeholder_text = placeholder.read_text(encoding="utf-8")
+    assert "InitialTargets/00_Target_Descriptions.bsh" in placeholder_text
+    assert "target-description lane" in placeholder_text
+
+
+def test_mkrf_source_reproducibility_boundary_records_p58_3c() -> None:
+    boundary_path = Path("metadata/legacy_source_reproducibility_boundary.yaml")
+
+    if not boundary_path.exists():
+        pytest.skip("MKRF instance submodule is not materialized")
+
+    boundary = yaml.safe_load(boundary_path.read_text(encoding="utf-8"))
+
+    assert boundary["phase"] == "P58.3c"
+    assert boundary["status"] == (
+        "reproducibility_boundary_published_no_source_faithful_claim"
+    )
+    assert boundary["decision"] == {
+        "raw_source_publication_boundary": "published",
+        "source_faithful_rebuild_claim": "not_permitted_yet",
+        "compiled_runtime_substitution": "rejected",
+        "checkpoint_substitution": "rejected",
+        "matrix_build_dependency": "unchanged",
+        "runnable_minimal_claim": "unchanged",
+    }
+    assert boundary["raw_source_lane"]["authoritative_upstream_families"] == [
+        "MKRF_Cosmin_Model/MKRF/03_MappingAnalysisData/Source.gdb",
+        "MKRF_Cosmin_Model/MKRF/03_MappingAnalysisData/Resultant.gdb",
+        "MKRF_Cosmin_Model/MKRF/03_MappingAnalysisData/Resultant_info_v1.xlsx",
+        "MKRF_Cosmin_Model/MKRF/03_MappingAnalysisData/03_Yields/VDYP/*",
+    ]
+    assert boundary["raw_source_lane"]["reconstructed_publication_contract"][
+        "published_runtime_target"
+    ] == {
+        "path_glob": "MKRF_Cosmin_Model/MKRF/04_Models/PW_MKRF/Spatial/fragments.*",
+        "feature_count": 1763,
+        "geometry_type": "Polygon",
+        "filter_expression": "CONTCLAS != 'X'",
+        "excluded_feature_count": 110,
+    }
+    assert boundary["rejected_substitutes"]["compiled_runtime"]["status"] == (
+        "not_raw_source"
+    )
+    assert boundary["rejected_substitutes"]["checkpoint_derived"]["status"] == (
+        "not_raw_source"
+    )
+    assert boundary["claim_boundary"]["allowed_now"] == [
+        (
+            "minimally_runnable_patchworks_instance_from_femic_managed_xml_plus_"
+            "accepted_compiled_spatial_inputs"
+        ),
+        "raw_source_publication_boundary_reconstructed_at_contract_level",
+    ]
+    assert boundary["claim_boundary"]["not_allowed_yet"] == [
+        "source_faithful_mkrf_rebuild",
+        (
+            "claim_that_runtime_fragments_or_topology_were_regenerated_from_"
+            "upstream_mapping_inputs"
+        ),
+        (
+            "claim_that_checkpoint_or_compiled_runtime_surfaces_are_equivalent_"
+            "to_raw_source"
+        ),
+    ]
+    assert boundary["next_bounded_step"] == {
+        "recommendation": "broaden_runtime_and_scenario_validation_beyond_minimal_launch",
+        "roadmap_task": "P58.4",
+    }
+
+
+def test_mkrf_runtime_xml_emission_records_p58_2_boundary() -> None:
+    emission_path = Path("metadata/legacy_runtime_xml_emission.yaml")
+
+    if not emission_path.exists():
+        pytest.skip("MKRF instance submodule is not materialized")
+
+    emission = yaml.safe_load(emission_path.read_text(encoding="utf-8"))
+
+    assert emission["phase"] == "P58.2"
+    assert emission["status"] == "runtime_xml_emitted_with_native_attribute_builder"
+    assert emission["decision"] == {
+        "runtime_xml_emission": "materialized",
+        "emission_mode": "opt_in_mkrf_contract_builder",
+        "generated_yield_curves": "inlined_from_curve_table_csv",
+        "native_attribute_builder": "materialized",
+        "matrix_build": "passed",
+        "launch_proof": "passed",
+        "runnable_rebuild_claim": "minimal_runnable",
+    }
+    assert emission["emitted_artifact"]["path"] == (
+        "models/mkrf_patchworks_model_poc/XML/baseMKRF.xml"
+    )
+    assert emission["emitted_artifact"]["sha256"] == (
+        "18b22086c44faa9dcd61ddfcf71156d15efee7b7bdcf09b9c7a27cf6bc1cb6e7"
+    )
+    assert emission["emitted_artifact"]["forest_model"] == {
+        "description": "Base TFL26",
+        "horizon_years": 300,
+        "start_year": 2020,
+        "max_age": 350,
+        "match": "multi",
+    }
+    assert emission["emitted_artifact"]["structure_counts"] == {
+        "defines": 12,
+        "curves": 1057,
+        "selects": 11,
+        "retentions": 2,
+        "treatments": 2,
+    }
+    assert emission["emitted_contract"]["define_fields"] == [
+        "status",
+        "au",
+        "auf",
+        "oper",
+        "ct",
+        "aux",
+        "treatment",
+        "managed",
+        "unmanaged",
+        "operable",
+        "lowoper",
+        "frd",
+    ]
+    assert emission["emitted_contract"]["input"] == {
+        "block": "Int(RES_KEY)",
+        "area": "Shape_Area/10000",
+        "age": "Int(AGE_2020)",
+        "exclude": "CONTCLAS eq 'X'",
+    }
+    assert emission["emitted_contract"]["inlined_generated_curve_source"] == {
+        "curve_count": 1049,
+        "producer": "data/legacy_mkrf/generated_xml/CSV/CURVE_TABLE.csv",
+    }
+    assert emission["phase"] == "P58.2"
+    assert emission["status"] == "runtime_xml_emitted_with_native_attribute_builder"
+    assert emission["decision"] == {
+        "runtime_xml_emission": "materialized",
+        "emission_mode": "opt_in_mkrf_contract_builder",
+        "generated_yield_curves": "inlined_from_curve_table_csv",
+        "native_attribute_builder": "materialized",
+        "matrix_build": "passed",
+        "launch_proof": "passed",
+        "runnable_rebuild_claim": "minimal_runnable",
+    }
+    assert emission["inputs"]["attribute_review_extract"] == (
+        "metadata/mkrf_xlsm_review/ranges/attrib_attributes.review.csv"
+    )
+    assert emission["inputs"]["species_lookup_review_extract"] == (
+        "metadata/mkrf_xlsm_review/ranges/lookups_spp_comp.review.csv"
+    )
+    assert emission["next_bounded_step"] == {
+        "recommendation": "reconstruct_raw_source_input_lane",
+        "roadmap_task": "P58.3",
+    }
+
+    runtime_xml = Path("models/mkrf_patchworks_model_poc/XML/baseMKRF.xml")
+    assert runtime_xml.exists()
+    root = et.parse(runtime_xml).getroot()
+    assert root.attrib == {
+        "description": "Base TFL26",
+        "horizon": "300",
+        "year": "2020",
+        "maxage": "350",
+        "match": "multi",
+    }
+    assert root.find("./curve[@id='Yield_1']") is not None
+    assert len(root.findall("./select")) == 11
+    assert root.find("./define[@field='frd']") is not None
+    assert (
+        root.find(".//features/attribute[@label='%f.area.%m.seral.le10']") is not None
+    )
+    assert root.find(".//features/attribute[@label='%f.yield.%m.indsp.Ba']") is not None
+
+
+def test_mkrf_attribute_passthrough_records_p57_4_boundary() -> None:
+    passthrough_path = Path("metadata/legacy_attribute_passthrough.yaml")
+
+    if not passthrough_path.exists():
+        pytest.skip("MKRF instance submodule is not materialized")
+
+    passthrough = yaml.safe_load(passthrough_path.read_text(encoding="utf-8"))
+
+    assert passthrough["phase"] == "P57.4"
+    assert passthrough["status"] == "attribute_passthrough_materialized_for_runtime_xml"
+    assert passthrough["decision"] == {
+        "passthrough_mode": "extracted_legacy_select_blocks",
+        "source_of_truth": "data/legacy_mkrf/generated_xml/baseMKRF.xml",
+        "native_attribute_builder": "not_implemented",
+        "compatibility_constant_dependencies": "materialized",
+        "matrix_build": "not_run",
+        "launch_proof": "not_run",
+        "runnable_rebuild_claim": "no_go",
+    }
+    assert passthrough["compatibility_contract"]["extracted_select_block_count"] == 5
+    assert passthrough["compatibility_contract"]["validated_dependencies"] == {
+        "define_fields": ["status", "au", "aux", "treatment", "managed", "frd"],
+        "curve_ids": ["one", "le10"],
+        "generated_curve_family": "Yield_*",
+        "required_attribute_labels": [
+            "%f.area.%m.total",
+            "%f.yield.%m.total",
+            "%f.yield.%m.merch.total",
+            "%f.yield.%m.indsp.Ba",
+            "%f.yield.%m.indsp.Cw",
+            "%f.yield.%m.indsp.Dec",
+            "%f.yield.%m.indsp.Fd",
+            "%f.yield.%m.indsp.Hw",
+            "%f.yield.%m.indsp.Oth",
+            "%f.yield.%m.indsp.Dr",
+            "%f.yield.%m.indsp.Yc",
+            "%f.area.%m.seral.le10",
+        ],
+    }
+    assert [
+        block["block_id"]
+        for block in passthrough["compatibility_contract"]["extracted_blocks"]
+    ] == [
+        "feature_area_and_total_yield",
+        "merchantable_total_yield",
+        "individual_species_yield",
+        "seral_le10_area",
+        "product_area_and_yield_family",
+    ]
+    assert passthrough["next_bounded_step"] == {
+        "recommendation": "wire_runtime_config_to_generated_model_directory",
+        "roadmap_task": "P57.5",
+    }
+
+
+def test_mkrf_runtime_config_points_to_generated_runtime_model() -> None:
+    config_path = Path("config/patchworks.runtime.windows.yaml")
+
+    if not config_path.exists():
+        pytest.skip("MKRF instance submodule is not materialized")
+
+    config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+
+    assert config["matrix_builder"] == {
+        "fragments_path": "../models/mkrf_patchworks_model_poc/Spatial/fragments.dbf",
+        "output_dir": "../models/mkrf_patchworks_model_poc/Tracks",
+        "forestmodel_xml_path": "../models/mkrf_patchworks_model_poc/XML/baseMKRF.xml",
+        "auto_close_window_on_success": True,
+        "auto_close_settle_seconds": 2.0,
+        "auto_close_timeout_seconds": 10.0,
+    }
+
+
+def test_mkrf_runtime_config_wiring_records_p57_5_boundary() -> None:
+    wiring_path = Path("metadata/legacy_runtime_config_wiring.yaml")
+
+    if not wiring_path.exists():
+        pytest.skip("MKRF instance submodule is not materialized")
+
+    wiring = yaml.safe_load(wiring_path.read_text(encoding="utf-8"))
+
+    assert wiring["phase"] == "P57.5"
+    assert wiring["status"] == "runtime_config_wired_and_preflight_validated"
+    assert wiring["decision"] == {
+        "runtime_config_wiring": "materialized",
+        "variant_registration": "builtin_registry_updated",
+        "preflight": "passed",
+        "matrix_build": "not_run",
+        "launch_proof": "not_run",
+        "runnable_rebuild_claim": "no_go",
+    }
+    assert wiring["runtime_surfaces"] == {
+        "runtime_config": "config/patchworks.runtime.windows.yaml",
+        "analysis_pin": "models/mkrf_patchworks_model_poc/analysis/base.pin",
+        "fragments_path": "models/mkrf_patchworks_model_poc/Spatial/fragments.dbf",
+        "forestmodel_xml_path": "models/mkrf_patchworks_model_poc/XML/baseMKRF.xml",
+        "tracks_output_dir": "models/mkrf_patchworks_model_poc/Tracks",
+        "builtin_variant": {
+            "variant_id": "mkrf.base",
+            "instance_id": "mkrf",
+            "analysis_pin": (
+                "external/femic-mkrf-instance/models/"
+                "mkrf_patchworks_model_poc/analysis/base.pin"
+            ),
+            "runtime_config": (
+                "external/femic-mkrf-instance/config/patchworks.runtime.windows.yaml"
+            ),
+        },
+    }
+    assert wiring["preflight_result"]["status"] == "passed"
+    assert wiring["preflight_result"]["license_host"] == "auth.spatial.ca"
+    assert wiring["next_bounded_step"] == {
+        "recommendation": "run_matrix_build_against_emitted_xml_and_accepted_spatial_inputs",
+        "roadmap_task": "P57.6",
+    }

--- a/tests/test_mkrf_managed.py
+++ b/tests/test_mkrf_managed.py
@@ -1,0 +1,519 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pandas as pd
+
+from mkrf_femic.pipeline.mkrf_managed import (
+    apply_hw_ingrowth_overlay,
+    build_mkrf_managed_au_bootstrap_table,
+    build_mkrf_managed_au_msyt_table,
+    build_mkrf_stand_origin_assignment,
+    classify_mkrf_origin,
+    load_mkrf_managed_rule_config,
+    parse_mkrf_managed_au_curves,
+    resolve_hw_ingrowth_pct,
+)
+from mkrf_femic.workflows.mkrf import build_mkrf_managed_au_curves
+
+
+def _write_managed_rules_yaml(tmp_path: Path) -> Path:
+    path = tmp_path / "tsamkrf.yaml"
+    path.write_text(
+        """
+schema_version: 1
+case_code: "mkrf"
+origin_rules:
+  fire_origin_min_age: 80
+managed_defaults:
+  density_total: 1500
+  regen_delay: 1
+  oaf1: 1.0
+  oaf2: 0.95
+  planted_percent: 100
+  baseline_system: "clearcut"
+  ct_eligible: true
+  ct_target_age: 40
+  ct_on_fire_origin: false
+families:
+  cwh_vm_1:
+    bec_zone: "cwh"
+    bec_subzone: "vm"
+    bec_variant: "1"
+    species_mix:
+      FD: 45
+      CW: 45
+      PW: 10
+  cwh_vm_2:
+    bec_zone: "cwh"
+    bec_subzone: "vm"
+    bec_variant: "2"
+    species_mix:
+      CW: 70
+      FD: 15
+      PW: 5
+      BA: 5
+      SS: 5
+""".strip(),
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_classify_mkrf_origin_uses_79_80_boundary() -> None:
+    assert classify_mkrf_origin(age_2020=79) == "logging_origin"
+    assert classify_mkrf_origin(age_2020=80) == "fire_origin"
+    assert classify_mkrf_origin(age_2020=None) == "unknown"
+
+
+def test_build_mkrf_stand_origin_assignment_publishes_origin_classes() -> None:
+    assignment = pd.DataFrame(
+        [
+            {
+                "forest_cover_id": 101,
+                "res_key": 1,
+                "shape_area_ha": 10.0,
+                "au_id": "cwh_vm_1_cw_fdc",
+                "bec_zone": "cwh",
+                "bec_subzone": "vm",
+                "bec_variant": "1",
+                "leading_species_1": "cw",
+                "leading_species_2": "fdc",
+            },
+            {
+                "forest_cover_id": 102,
+                "res_key": 2,
+                "shape_area_ha": 11.0,
+                "au_id": "cwh_vm_1_cw_fdc",
+                "bec_zone": "cwh",
+                "bec_subzone": "vm",
+                "bec_variant": "1",
+                "leading_species_1": "cw",
+                "leading_species_2": "fdc",
+            },
+        ]
+    )
+    source_table = pd.DataFrame(
+        [
+            {
+                "FOREST_COVER_ID": 101,
+                "AGE_2020": 79,
+                "TCL_1_ESTIMATED_SITE_INDEX": 24.0,
+            },
+            {
+                "FOREST_COVER_ID": 102,
+                "AGE_2020": 80,
+                "TCL_1_ESTIMATED_SITE_INDEX": 30.0,
+            },
+        ]
+    )
+
+    out = build_mkrf_stand_origin_assignment(
+        assignment=assignment,
+        source_table=source_table,
+        fire_origin_min_age=80.0,
+    )
+
+    assert out["forest_cover_id"].tolist() == [101, 102]
+    assert out["origin_class"].tolist() == ["logging_origin", "fire_origin"]
+    assert out["site_index"].tolist() == [24.0, 30.0]
+
+
+def test_hw_ingrowth_overlay_resolves_and_transfers_species_mix(tmp_path: Path) -> None:
+    rules_yaml = tmp_path / "tsamkrf.yaml"
+    rules_yaml.write_text(
+        """
+schema_version: 1
+case_code: "mkrf"
+hw_ingrowth_overlay:
+  enabled: true
+  landscape_default_pct: 10
+  au_overrides_pct:
+    cwh_vm_2_cw_hw: 20
+  stand_overrides_pct:
+    "202": 30
+families:
+  cwh_vm_1:
+    bec_zone: "cwh"
+    bec_subzone: "vm"
+    bec_variant: "1"
+    species_mix:
+      FD: 45
+      CW: 45
+      PW: 10
+  cwh_vm_2:
+    bec_zone: "cwh"
+    bec_subzone: "vm"
+    bec_variant: "2"
+    species_mix:
+      CW: 70
+      FD: 15
+      PW: 5
+      BA: 5
+      SS: 5
+""".strip(),
+        encoding="utf-8",
+    )
+    rule_config = load_mkrf_managed_rule_config(rules_yaml)
+
+    assert resolve_hw_ingrowth_pct(
+        rule_config=rule_config,
+        au_id="cwh_vm_1_cw_fdc",
+    ) == (10.0, "landscape_default")
+    assert resolve_hw_ingrowth_pct(
+        rule_config=rule_config,
+        au_id="cwh_vm_2_cw_hw",
+    ) == (20.0, "au_override")
+    assert resolve_hw_ingrowth_pct(
+        rule_config=rule_config,
+        au_id="cwh_vm_2_cw_hw",
+        stand_id=202,
+    ) == (30.0, "stand_override")
+
+    assert apply_hw_ingrowth_overlay(
+        species_mix={"CW": 80, "FD": 20},
+        hw_ingrowth_pct=10,
+    ) == {"CW": 72.0, "FD": 18.0, "HW": 10.0}
+
+
+def test_build_mkrf_managed_au_bootstrap_table_applies_hw_ingrowth_overlay(
+    tmp_path: Path,
+) -> None:
+    rules_yaml = tmp_path / "tsamkrf.yaml"
+    rules_yaml.write_text(
+        """
+schema_version: 1
+case_code: "mkrf"
+hw_ingrowth_overlay:
+  enabled: true
+  landscape_default_pct: 30
+families:
+  cwh_vm_2:
+    bec_zone: "cwh"
+    bec_subzone: "vm"
+    bec_variant: "2"
+    species_mix:
+      CW: 70
+      FD: 15
+      PW: 5
+      BA: 5
+      SS: 5
+""".strip(),
+        encoding="utf-8",
+    )
+    rule_config = load_mkrf_managed_rule_config(rules_yaml)
+    selected_au_table = pd.DataFrame(
+        [
+            {
+                "au_id": "cwh_vm_2_cw_hw",
+                "selected_rank": 1,
+                "covered_area_ha": 100.0,
+                "bec_zone": "cwh",
+                "bec_subzone": "vm",
+                "bec_variant": "2",
+                "leading_species_1": "cw",
+                "leading_species_2": "hw",
+            },
+        ]
+    )
+    stand_origin_assignment = pd.DataFrame(
+        [
+            {
+                "forest_cover_id": 201,
+                "au_id": "cwh_vm_2_cw_hw",
+                "origin_class": "logging_origin",
+                "site_index": 24.0,
+            },
+        ]
+    )
+
+    out = build_mkrf_managed_au_bootstrap_table(
+        selected_au_table=selected_au_table,
+        stand_origin_assignment=stand_origin_assignment,
+        rule_config=rule_config,
+    )
+
+    row = out.iloc[0]
+    assert row["base_managed_species_1"] == "CW"
+    assert row["base_managed_pct_1"] == 70.0
+    assert row["hw_ingrowth_pct"] == 30.0
+    assert row["hw_ingrowth_source"] == "landscape_default"
+    assert row["managed_species_1"] == "CW"
+    assert row["managed_pct_1"] == 49.0
+    assert row["managed_species_2"] == "HW"
+    assert row["managed_pct_2"] == 33.5
+    assert row["managed_species_3"] == "FD"
+    assert row["managed_pct_3"] == 10.5
+    assert row["managed_species_overflow_to_hw_pct"] == 3.5
+    assert row["managed_species_overflow_to_hw_codes"] == "SS"
+
+
+def test_build_mkrf_managed_au_bootstrap_table_uses_expert_rules_and_si_fallback(
+    tmp_path: Path,
+) -> None:
+    rules_yaml = _write_managed_rules_yaml(tmp_path)
+    rule_config = load_mkrf_managed_rule_config(rules_yaml)
+    selected_au_table = pd.DataFrame(
+        [
+            {
+                "au_id": "cwh_vm_1_cw_fdc",
+                "selected_rank": 1,
+                "covered_area_ha": 100.0,
+                "bec_zone": "cwh",
+                "bec_subzone": "vm",
+                "bec_variant": "1",
+                "leading_species_1": "cw",
+                "leading_species_2": "fdc",
+            },
+            {
+                "au_id": "cwh_vm_2_cw_hw",
+                "selected_rank": 2,
+                "covered_area_ha": 80.0,
+                "bec_zone": "cwh",
+                "bec_subzone": "vm",
+                "bec_variant": "2",
+                "leading_species_1": "cw",
+                "leading_species_2": "hw",
+            },
+            {
+                "au_id": "mh_mm_1_hw_cw",
+                "selected_rank": 3,
+                "covered_area_ha": 10.0,
+                "bec_zone": "mh",
+                "bec_subzone": "mm",
+                "bec_variant": "1",
+                "leading_species_1": "hw",
+                "leading_species_2": "cw",
+            },
+        ]
+    )
+    stand_origin_assignment = pd.DataFrame(
+        [
+            {
+                "forest_cover_id": 101,
+                "au_id": "cwh_vm_1_cw_fdc",
+                "origin_class": "logging_origin",
+                "site_index": 24.0,
+            },
+            {
+                "forest_cover_id": 102,
+                "au_id": "cwh_vm_1_cw_fdc",
+                "origin_class": "logging_origin",
+                "site_index": 30.0,
+            },
+            {
+                "forest_cover_id": 103,
+                "au_id": "cwh_vm_1_cw_fdc",
+                "origin_class": "fire_origin",
+                "site_index": 36.0,
+            },
+            {
+                "forest_cover_id": 201,
+                "au_id": "cwh_vm_2_cw_hw",
+                "origin_class": "fire_origin",
+                "site_index": 21.0,
+            },
+            {
+                "forest_cover_id": 202,
+                "au_id": "cwh_vm_2_cw_hw",
+                "origin_class": "fire_origin",
+                "site_index": 27.0,
+            },
+        ]
+    )
+
+    out = build_mkrf_managed_au_bootstrap_table(
+        selected_au_table=selected_au_table,
+        stand_origin_assignment=stand_origin_assignment,
+        rule_config=rule_config,
+    )
+
+    vm1 = out.loc[out["au_id"] == "cwh_vm_1_cw_fdc"].iloc[0]
+    assert vm1["bootstrap_status"] == "expert_rule"
+    assert vm1["managed_si_source"] == "logging_origin_median"
+    assert vm1["managed_si"] == 27.0
+    assert vm1["managed_species_1"] == "CW"
+    assert vm1["managed_species_2"] == "FD"
+    assert vm1["managed_species_3"] == "PW"
+    assert vm1["density_total"] == 1500
+    assert bool(vm1["ct_eligible"]) is True
+    assert vm1["managed_rule_source"].endswith("tsamkrf.yaml")
+    assert ":" not in vm1["managed_rule_source"]
+
+    vm2 = out.loc[out["au_id"] == "cwh_vm_2_cw_hw"].iloc[0]
+    assert vm2["bootstrap_status"] == "expert_rule"
+    assert vm2["managed_si_source"] == "all_stands_median"
+    assert vm2["managed_si"] == 24.0
+    assert vm2["managed_species_1"] == "CW"
+    assert vm2["managed_species_2"] == "FD"
+    assert vm2["managed_species_3"] == "BA"
+    assert vm2["managed_species_4"] == "PW"
+    assert vm2["managed_species_5"] == "SS"
+
+    unmatched = out.loc[out["au_id"] == "mh_mm_1_hw_cw"].iloc[0]
+    assert unmatched["bootstrap_status"] == "unmatched"
+    assert unmatched["mapping_path"] == "no_matching_managed_rule"
+
+
+def test_build_mkrf_managed_au_msyt_table_supports_pw_ss_species() -> None:
+    bootstrap_table = pd.DataFrame(
+        [
+            {
+                "au_id": "cwh_vm_2_cw_hw",
+                "selected_rank": 2,
+                "bec_zone": "cwh",
+                "bec_subzone": "vm",
+                "bec_variant": "2",
+                "managed_curve_id": 60002,
+                "included_in_msyt": True,
+                "managed_si": 24.0,
+                "regen_delay": 1,
+                "density_total": 1500,
+                "oaf1": 1.0,
+                "oaf2": 0.95,
+                "managed_species_1": "CW",
+                "managed_species_2": "FD",
+                "managed_species_3": "PW",
+                "managed_species_4": "BA",
+                "managed_species_5": "SS",
+                "managed_pct_1": 70.0,
+                "managed_pct_2": 15.0,
+                "managed_pct_3": 5.0,
+                "managed_pct_4": 5.0,
+                "managed_pct_5": 5.0,
+            }
+        ]
+    )
+
+    out = build_mkrf_managed_au_msyt_table(bootstrap_table=bootstrap_table)
+
+    row = out.iloc[0].to_dict()
+    assert row["feature_id"] == 60002
+    assert row["planted_species1"] == "Cw"
+    assert row["planted_species2"] == "Fd"
+    assert row["planted_species3"] == "Pw"
+    assert row["planted_species4"] == "Ba"
+    assert row["planted_species5"] == "Ss"
+    assert row["cw_si"] == 24.0
+    assert row["fd_si"] == 24.0
+    assert row["pw_si"] == 24.0
+    assert row["ss_si"] == 24.0
+    assert row["planted_density1"] == 1050
+
+
+def test_build_mkrf_managed_au_msyt_table_rebalances_fractional_density_rounding() -> (
+    None
+):
+    bootstrap_table = pd.DataFrame(
+        [
+            {
+                "au_id": "cwh_vm_1_cw_hw",
+                "selected_rank": 1,
+                "bec_zone": "cwh",
+                "bec_subzone": "vm",
+                "bec_variant": "1",
+                "managed_curve_id": 60001,
+                "included_in_msyt": True,
+                "managed_si": 24.0,
+                "regen_delay": 1,
+                "density_total": 1500,
+                "oaf1": 1.0,
+                "oaf2": 0.95,
+                "managed_species_1": "HW",
+                "managed_species_2": "CW",
+                "managed_species_3": "FD",
+                "managed_species_4": "PW",
+                "managed_species_5": "",
+                "managed_pct_1": 50.0,
+                "managed_pct_2": 22.5,
+                "managed_pct_3": 22.5,
+                "managed_pct_4": 5.0,
+                "managed_pct_5": 0.0,
+            }
+        ]
+    )
+
+    out = build_mkrf_managed_au_msyt_table(bootstrap_table=bootstrap_table)
+
+    row = out.iloc[0].to_dict()
+    densities = [row[f"planted_density{index}"] or 0 for index in range(1, 6)]
+    assert sum(densities) == 1500
+    assert densities[:4] == [750, 338, 337, 75]
+
+
+def test_parse_mkrf_managed_au_curves_maps_back_to_au_id(tmp_path: Path) -> None:
+    bootstrap_table = pd.DataFrame(
+        [
+            {
+                "au_id": "cwh_vm_1_cw_fdc",
+                "managed_curve_id": 60001,
+                "included_in_msyt": True,
+            }
+        ]
+    )
+    output_csv = tmp_path / "managed_output.csv"
+    pd.DataFrame(
+        [
+            {
+                "feature_id": 60001,
+                "MVcon_0": 0.0,
+                "MVdec_0": 0.0,
+                "HTcon_0": 0.0,
+                "HTdec_0": 0.0,
+                "gVol_0": 0.0,
+                "CC_0": 0.0,
+                "MVcon_10": 55.0,
+                "MVdec_10": 5.0,
+                "HTcon_10": 3.5,
+                "HTdec_10": 0.0,
+                "gVol_10": 65.0,
+                "CC_10": 0.5,
+            }
+        ]
+    ).to_csv(output_csv, index=False)
+
+    out = parse_mkrf_managed_au_curves(
+        output_csv=output_csv,
+        bootstrap_table=bootstrap_table,
+    )
+
+    assert out["au_id"].unique().tolist() == ["cwh_vm_1_cw_fdc"]
+    assert out["managed_curve_id"].unique().tolist() == [60001]
+    assert out["age"].tolist() == [0, 10]
+    assert out["volume"].tolist() == [0.0, 60.0]
+
+
+def test_build_mkrf_managed_au_curves_writes_blocked_manifest(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    bootstrap_csv = tmp_path / "managed_au_bootstrap_table.csv"
+    msyt_csv = tmp_path / "managed_au_msyt.csv"
+    pd.DataFrame(
+        [
+            {
+                "au_id": "cwh_vm_1_cw_fdc",
+                "managed_curve_id": 60001,
+                "included_in_msyt": True,
+            }
+        ]
+    ).to_csv(bootstrap_csv, index=False)
+    pd.DataFrame([{"feature_id": 60001}]).to_csv(msyt_csv, index=False)
+
+    def _missing_btc(**_kwargs: object) -> None:
+        raise FileNotFoundError("TIPSYbtc.exe not found")
+
+    monkeypatch.setattr("mkrf_femic.workflows.mkrf.run_btc_cli", _missing_btc)
+
+    result = build_mkrf_managed_au_curves(
+        bootstrap_csv=bootstrap_csv,
+        msyt_csv=msyt_csv,
+        output_dir=tmp_path,
+        log_dir=tmp_path / "logs",
+    )
+
+    manifest = json.loads(result.manifest_path.read_text(encoding="utf-8"))
+    assert result.status == "blocked"
+    assert manifest["reason"] == "missing_btc_runtime"
+    assert result.curves_path is None

--- a/tests/test_mkrf_plots.py
+++ b/tests/test_mkrf_plots.py
@@ -1,0 +1,758 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import matplotlib
+import pandas as pd
+import pytest
+
+from mkrf_femic.pipeline.mkrf_managed import build_mkrf_legacy_managed_au_table
+from mkrf_femic.workflows.mkrf import (
+    MkrfAuPlotResult,
+    _classify_site_index_levels,
+    _filter_assignment_to_selected_aus,
+    build_mkrf_all_plots,
+)
+
+matplotlib.use("Agg")
+
+
+def test_classify_site_index_levels_splits_into_lmh_bins() -> None:
+    levels = _classify_site_index_levels(
+        pd.Series([10.0, 12.0, 20.0, 25.0, 35.0, 40.0])
+    )
+    assert list(levels.astype(str)) == ["L", "L", "M", "M", "H", "H"]
+
+
+def test_build_tipsy_legacy_au_table_derives_bec_and_species_pair() -> None:
+    man_si_by_au = pd.DataFrame(
+        [
+            {"AU": 101, "BEC": "CWHvm2", "SI": 28.5},
+            {"AU": 102, "BEC": "MHmm1", "SI": 18.0},
+        ]
+    )
+    tipsy_spp_comp = pd.DataFrame(
+        [
+            {
+                "AU": 101,
+                "BA": 10.0,
+                "CW": 45.0,
+                "DR": 0.0,
+                "FD": 0.0,
+                "HW": 45.0,
+                "YC": 0.0,
+            },
+            {
+                "AU": 102,
+                "BA": 0.0,
+                "CW": 0.0,
+                "DR": 20.0,
+                "FD": 60.0,
+                "HW": 20.0,
+                "YC": 0.0,
+            },
+        ]
+    )
+
+    legacy = build_mkrf_legacy_managed_au_table(
+        man_si_by_au=man_si_by_au,
+        tipsy_spp_comp=tipsy_spp_comp,
+    ).sort_values("AU", kind="stable")
+
+    assert list(legacy["bec_zone"]) == ["cwh", "mhm"]
+    assert list(legacy["bec_subzone"]) == ["vm", "m"]
+    assert list(legacy["bec_variant"]) == ["2", "1"]
+    assert list(legacy["leading_species_1"]) == ["cw", "fdc"]
+    assert list(legacy["leading_species_2"]) == ["hw", "dr"]
+    assert list(legacy["legacy_candidate_au_id"]) == [
+        "cwh_vm_2_cw_hw",
+        "mhm_m_1_fdc_dr",
+    ]
+
+
+def test_filter_assignment_to_selected_aus_keeps_only_selected_rows() -> None:
+    assignment = pd.DataFrame(
+        [
+            {"res_key": 1, "au_id": "a"},
+            {"res_key": 2, "au_id": "b"},
+            {"res_key": 3, "au_id": "c"},
+        ]
+    )
+    selected = pd.DataFrame(
+        [
+            {"au_id": "b", "selected_rank": 1},
+            {"au_id": "c", "selected_rank": 2},
+        ]
+    )
+
+    filtered = _filter_assignment_to_selected_aus(assignment, selected)
+
+    assert list(filtered["res_key"]) == [2, 3]
+    assert list(filtered["au_id"]) == ["b", "c"]
+
+
+def test_build_mkrf_all_plots_uses_managed_curve_bundle(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    assignment_csv = tmp_path / "stand_au_assignment.csv"
+    selected_au_csv = tmp_path / "selected_au_table.csv"
+    first_growth_curves_csv = tmp_path / "first_growth_au_curves.csv"
+    managed_curves_csv = tmp_path / "managed_au_curves.csv"
+    vdyp_yields_csv = tmp_path / "vdyp_yields.csv"
+    output_dir = tmp_path / "plots"
+
+    pd.DataFrame(
+        [
+            {
+                "res_key": 1,
+                "forest_cover_id": 101,
+                "shape_area_ha": 10.0,
+                "au_id": "cwh_dm_x_cw_fdc",
+            },
+            {
+                "res_key": 2,
+                "forest_cover_id": 102,
+                "shape_area_ha": 10.0,
+                "au_id": "cwh_dm_x_cw_fdc",
+            },
+            {
+                "res_key": 3,
+                "forest_cover_id": 103,
+                "shape_area_ha": 10.0,
+                "au_id": "cwh_dm_x_cw_fdc",
+            },
+            {
+                "res_key": 4,
+                "forest_cover_id": 104,
+                "shape_area_ha": 10.0,
+                "au_id": "cwh_dm_x_cw_fdc",
+            },
+            {
+                "res_key": 4,
+                "forest_cover_id": 104,
+                "shape_area_ha": 10.0,
+                "au_id": "cwh_dm_x_cw_fdc",
+            },
+        ]
+    ).to_csv(assignment_csv, index=False)
+    pd.DataFrame(
+        [
+            {
+                "au_id": "cwh_dm_x_cw_fdc",
+                "selected_rank": 1,
+                "covered_area_ha": 30.0,
+                "bec_zone": "cwh",
+                "bec_subzone": "dm",
+                "bec_variant": "x",
+                "leading_species_1": "cw",
+                "leading_species_2": "fdc",
+            }
+        ]
+    ).to_csv(selected_au_csv, index=False)
+    pd.DataFrame(
+        [
+            {"au_id": "cwh_dm_x_cw_fdc", "age": 0, "volume": 0.0},
+            {"au_id": "cwh_dm_x_cw_fdc", "age": 10, "volume": 50.0},
+            {"au_id": "cwh_dm_x_cw_fdc", "age": 20, "volume": 100.0},
+        ]
+    ).to_csv(first_growth_curves_csv, index=False)
+    pd.DataFrame(
+        [
+            {
+                "au_id": "cwh_dm_x_cw_fdc",
+                "managed_curve_id": 60001,
+                "age": 0,
+                "volume": 0.0,
+            },
+            {
+                "au_id": "cwh_dm_x_cw_fdc",
+                "managed_curve_id": 60001,
+                "age": 10,
+                "volume": 60.0,
+            },
+            {
+                "au_id": "cwh_dm_x_cw_fdc",
+                "managed_curve_id": 60001,
+                "age": 20,
+                "volume": 110.0,
+            },
+        ]
+    ).to_csv(managed_curves_csv, index=False)
+    pd.DataFrame(
+        [
+            {"FEATURE_ID": 101, "PRJ_TOTAL_AGE": 30, "PRJ_VOL_DWB": 20.0},
+            {"FEATURE_ID": 101, "PRJ_TOTAL_AGE": 40, "PRJ_VOL_DWB": 40.0},
+            {"FEATURE_ID": 101, "PRJ_TOTAL_AGE": 50, "PRJ_VOL_DWB": 85.0},
+            {"FEATURE_ID": 102, "PRJ_TOTAL_AGE": 30, "PRJ_VOL_DWB": 25.0},
+            {"FEATURE_ID": 102, "PRJ_TOTAL_AGE": 40, "PRJ_VOL_DWB": 45.0},
+            {"FEATURE_ID": 102, "PRJ_TOTAL_AGE": 50, "PRJ_VOL_DWB": 90.0},
+            {"FEATURE_ID": 103, "PRJ_TOTAL_AGE": 30, "PRJ_VOL_DWB": 30.0},
+            {"FEATURE_ID": 103, "PRJ_TOTAL_AGE": 40, "PRJ_VOL_DWB": 50.0},
+            {"FEATURE_ID": 103, "PRJ_TOTAL_AGE": 50, "PRJ_VOL_DWB": 95.0},
+            {"FEATURE_ID": 104, "PRJ_TOTAL_AGE": 30, "PRJ_VOL_DWB": 22.0},
+            {"FEATURE_ID": 104, "PRJ_TOTAL_AGE": 40, "PRJ_VOL_DWB": 42.0},
+            {"FEATURE_ID": 104, "PRJ_TOTAL_AGE": 50, "PRJ_VOL_DWB": 88.0},
+            {"FEATURE_ID": 104, "PRJ_TOTAL_AGE": 0, "PRJ_VOL_DWB": 0.0},
+            {"FEATURE_ID": 104, "PRJ_TOTAL_AGE": 10, "PRJ_VOL_DWB": 42.0},
+            {"FEATURE_ID": 104, "PRJ_TOTAL_AGE": 20, "PRJ_VOL_DWB": 88.0},
+        ]
+    ).to_csv(vdyp_yields_csv, index=False)
+
+    def _fake_distribution_plot(**_: object) -> MkrfAuPlotResult:
+        strata_png = output_dir / "strata-tsamkrf.png"
+        strata_pdf = output_dir / "strata-tsamkrf.pdf"
+        output_dir.mkdir(parents=True, exist_ok=True)
+        strata_png.write_bytes(b"png")
+        strata_pdf.write_bytes(b"pdf")
+        return MkrfAuPlotResult(
+            resultant_gdb=tmp_path / "resultant.gdb",
+            assignment_csv=assignment_csv,
+            output_dir=output_dir,
+            png_path=strata_png,
+            pdf_path=strata_pdf,
+            au_count=1,
+            point_count=3,
+            metadata=None,  # type: ignore[arg-type]
+        )
+
+    source_table = pd.DataFrame(
+        [
+            {"FOREST_COVER_ID": 101, "TCL_1_ESTIMATED_SITE_INDEX": 20.0},
+            {"FOREST_COVER_ID": 102, "TCL_1_ESTIMATED_SITE_INDEX": 25.0},
+            {"FOREST_COVER_ID": 103, "TCL_1_ESTIMATED_SITE_INDEX": 30.0},
+        ]
+    )
+
+    monkeypatch.setattr(
+        "mkrf_femic.workflows.mkrf.build_mkrf_au_distribution_plot",
+        _fake_distribution_plot,
+    )
+    monkeypatch.setattr(
+        "mkrf_femic.workflows.mkrf.gpd.read_file", lambda *args, **kwargs: source_table
+    )
+
+    result = build_mkrf_all_plots(
+        resultant_gdb=tmp_path / "resultant.gdb",
+        assignment_csv=assignment_csv,
+        selected_au_csv=selected_au_csv,
+        first_growth_curves_csv=first_growth_curves_csv,
+        managed_curves_csv=managed_curves_csv,
+        vdyp_yields_csv=vdyp_yields_csv,
+        output_dir=output_dir,
+    )
+
+    assert result.tipsy_vdyp_plot_count == 1
+    assert any(output_dir.glob("tipsy_vdyp_tsamkrf-*.png"))
+
+
+def test_build_mkrf_all_plots_removes_stale_plot_files(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    assignment_csv = tmp_path / "stand_au_assignment.csv"
+    selected_au_csv = tmp_path / "selected_au_table.csv"
+    first_growth_curves_csv = tmp_path / "first_growth_au_curves.csv"
+    managed_curves_csv = tmp_path / "managed_au_curves.csv"
+    vdyp_yields_csv = tmp_path / "vdyp_yields.csv"
+    output_dir = tmp_path / "plots"
+    output_dir.mkdir(parents=True)
+
+    stale_tipsy = output_dir / "tipsy_vdyp_tsamkrf-stale.png"
+    stale_lmh = output_dir / "vdyp_lmh_tsamkrf-stale.png"
+    stale_fit = output_dir / "vdyp_fitdiag_tsamkrf-stale.png"
+    stale_tipsy.write_bytes(b"old")
+    stale_lmh.write_bytes(b"old")
+    stale_fit.write_bytes(b"old")
+
+    pd.DataFrame(
+        [
+            {
+                "res_key": 1,
+                "forest_cover_id": 101,
+                "shape_area_ha": 10.0,
+                "au_id": "cwh_dm_x_cw_fdc",
+            },
+            {
+                "res_key": 2,
+                "forest_cover_id": 102,
+                "shape_area_ha": 10.0,
+                "au_id": "cwh_dm_x_cw_fdc",
+            },
+            {
+                "res_key": 3,
+                "forest_cover_id": 103,
+                "shape_area_ha": 10.0,
+                "au_id": "cwh_dm_x_cw_fdc",
+            },
+            {
+                "res_key": 4,
+                "forest_cover_id": 104,
+                "shape_area_ha": 10.0,
+                "au_id": "cwh_dm_x_cw_fdc",
+            },
+        ]
+    ).to_csv(assignment_csv, index=False)
+    pd.DataFrame(
+        [
+            {
+                "au_id": "cwh_dm_x_cw_fdc",
+                "selected_rank": 1,
+                "covered_area_ha": 30.0,
+                "bec_zone": "cwh",
+                "bec_subzone": "dm",
+                "bec_variant": "x",
+                "leading_species_1": "cw",
+                "leading_species_2": "fdc",
+            }
+        ]
+    ).to_csv(selected_au_csv, index=False)
+    pd.DataFrame(
+        [
+            {"au_id": "cwh_dm_x_cw_fdc", "age": 0, "volume": 0.0},
+            {"au_id": "cwh_dm_x_cw_fdc", "age": 10, "volume": 50.0},
+            {"au_id": "cwh_dm_x_cw_fdc", "age": 20, "volume": 100.0},
+        ]
+    ).to_csv(first_growth_curves_csv, index=False)
+    pd.DataFrame(
+        [
+            {
+                "au_id": "cwh_dm_x_cw_fdc",
+                "managed_curve_id": 60001,
+                "age": 0,
+                "volume": 0.0,
+            },
+            {
+                "au_id": "cwh_dm_x_cw_fdc",
+                "managed_curve_id": 60001,
+                "age": 10,
+                "volume": 60.0,
+            },
+            {
+                "au_id": "cwh_dm_x_cw_fdc",
+                "managed_curve_id": 60001,
+                "age": 20,
+                "volume": 110.0,
+            },
+        ]
+    ).to_csv(managed_curves_csv, index=False)
+    pd.DataFrame(
+        [
+            {"FEATURE_ID": 101, "PRJ_TOTAL_AGE": 30, "PRJ_VOL_DWB": 20.0},
+            {"FEATURE_ID": 101, "PRJ_TOTAL_AGE": 40, "PRJ_VOL_DWB": 40.0},
+            {"FEATURE_ID": 101, "PRJ_TOTAL_AGE": 50, "PRJ_VOL_DWB": 85.0},
+            {"FEATURE_ID": 102, "PRJ_TOTAL_AGE": 30, "PRJ_VOL_DWB": 25.0},
+            {"FEATURE_ID": 102, "PRJ_TOTAL_AGE": 40, "PRJ_VOL_DWB": 45.0},
+            {"FEATURE_ID": 102, "PRJ_TOTAL_AGE": 50, "PRJ_VOL_DWB": 90.0},
+            {"FEATURE_ID": 103, "PRJ_TOTAL_AGE": 30, "PRJ_VOL_DWB": 30.0},
+            {"FEATURE_ID": 103, "PRJ_TOTAL_AGE": 40, "PRJ_VOL_DWB": 50.0},
+            {"FEATURE_ID": 103, "PRJ_TOTAL_AGE": 50, "PRJ_VOL_DWB": 95.0},
+            {"FEATURE_ID": 104, "PRJ_TOTAL_AGE": 30, "PRJ_VOL_DWB": 22.0},
+            {"FEATURE_ID": 104, "PRJ_TOTAL_AGE": 40, "PRJ_VOL_DWB": 42.0},
+            {"FEATURE_ID": 104, "PRJ_TOTAL_AGE": 50, "PRJ_VOL_DWB": 88.0},
+        ]
+    ).to_csv(vdyp_yields_csv, index=False)
+
+    def _fake_distribution_plot(**_: object) -> MkrfAuPlotResult:
+        strata_png = output_dir / "strata-tsamkrf.png"
+        strata_pdf = output_dir / "strata-tsamkrf.pdf"
+        strata_png.write_bytes(b"png")
+        strata_pdf.write_bytes(b"pdf")
+        return MkrfAuPlotResult(
+            resultant_gdb=tmp_path / "resultant.gdb",
+            assignment_csv=assignment_csv,
+            output_dir=output_dir,
+            png_path=strata_png,
+            pdf_path=strata_pdf,
+            au_count=1,
+            point_count=3,
+            metadata=None,  # type: ignore[arg-type]
+        )
+
+    source_table = pd.DataFrame(
+        [
+            {"FOREST_COVER_ID": 101, "TCL_1_ESTIMATED_SITE_INDEX": 20.0},
+            {"FOREST_COVER_ID": 102, "TCL_1_ESTIMATED_SITE_INDEX": 25.0},
+            {"FOREST_COVER_ID": 103, "TCL_1_ESTIMATED_SITE_INDEX": 30.0},
+        ]
+    )
+
+    monkeypatch.setattr(
+        "mkrf_femic.workflows.mkrf.build_mkrf_au_distribution_plot",
+        _fake_distribution_plot,
+    )
+    monkeypatch.setattr(
+        "mkrf_femic.workflows.mkrf.gpd.read_file", lambda *args, **kwargs: source_table
+    )
+
+    build_mkrf_all_plots(
+        resultant_gdb=tmp_path / "resultant.gdb",
+        assignment_csv=assignment_csv,
+        selected_au_csv=selected_au_csv,
+        first_growth_curves_csv=first_growth_curves_csv,
+        managed_curves_csv=managed_curves_csv,
+        vdyp_yields_csv=vdyp_yields_csv,
+        output_dir=output_dir,
+    )
+
+    assert stale_tipsy.exists() is False
+    assert stale_lmh.exists() is False
+    assert stale_fit.exists() is False
+
+
+def test_build_mkrf_all_plots_applies_age_floor_to_lmh_diagnostics(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    assignment_csv = tmp_path / "stand_au_assignment.csv"
+    selected_au_csv = tmp_path / "selected_au_table.csv"
+    first_growth_curves_csv = tmp_path / "first_growth_au_curves.csv"
+    managed_curves_csv = tmp_path / "managed_au_curves.csv"
+    vdyp_yields_csv = tmp_path / "vdyp_yields.csv"
+    output_dir = tmp_path / "plots"
+
+    pd.DataFrame(
+        [
+            {
+                "res_key": 1,
+                "forest_cover_id": 101,
+                "shape_area_ha": 10.0,
+                "au_id": "cwh_dm_x_cw_fdc",
+            },
+            {
+                "res_key": 2,
+                "forest_cover_id": 102,
+                "shape_area_ha": 10.0,
+                "au_id": "cwh_dm_x_cw_fdc",
+            },
+            {
+                "res_key": 3,
+                "forest_cover_id": 103,
+                "shape_area_ha": 10.0,
+                "au_id": "cwh_dm_x_cw_fdc",
+            },
+            {
+                "res_key": 4,
+                "forest_cover_id": 104,
+                "shape_area_ha": 10.0,
+                "au_id": "cwh_dm_x_cw_fdc",
+            },
+        ]
+    ).to_csv(assignment_csv, index=False)
+    pd.DataFrame(
+        [
+            {
+                "au_id": "cwh_dm_x_cw_fdc",
+                "selected_rank": 1,
+                "covered_area_ha": 30.0,
+                "bec_zone": "cwh",
+                "bec_subzone": "dm",
+                "bec_variant": "x",
+                "leading_species_1": "cw",
+                "leading_species_2": "fdc",
+            }
+        ]
+    ).to_csv(selected_au_csv, index=False)
+    pd.DataFrame(
+        [
+            {"au_id": "cwh_dm_x_cw_fdc", "age": 0, "volume": 0.0},
+            {"au_id": "cwh_dm_x_cw_fdc", "age": 10, "volume": 50.0},
+            {"au_id": "cwh_dm_x_cw_fdc", "age": 20, "volume": 100.0},
+        ]
+    ).to_csv(first_growth_curves_csv, index=False)
+    pd.DataFrame(
+        [
+            {
+                "au_id": "cwh_dm_x_cw_fdc",
+                "managed_curve_id": 60001,
+                "age": 0,
+                "volume": 0.0,
+            },
+            {
+                "au_id": "cwh_dm_x_cw_fdc",
+                "managed_curve_id": 60001,
+                "age": 10,
+                "volume": 60.0,
+            },
+            {
+                "au_id": "cwh_dm_x_cw_fdc",
+                "managed_curve_id": 60001,
+                "age": 20,
+                "volume": 110.0,
+            },
+        ]
+    ).to_csv(managed_curves_csv, index=False)
+    pd.DataFrame(
+        [
+            {"FEATURE_ID": 101, "PRJ_TOTAL_AGE": 0, "PRJ_VOL_DWB": 0.0},
+            {"FEATURE_ID": 101, "PRJ_TOTAL_AGE": 10, "PRJ_VOL_DWB": 40.0},
+            {"FEATURE_ID": 101, "PRJ_TOTAL_AGE": 20, "PRJ_VOL_DWB": 85.0},
+            {"FEATURE_ID": 102, "PRJ_TOTAL_AGE": 0, "PRJ_VOL_DWB": 0.0},
+            {"FEATURE_ID": 102, "PRJ_TOTAL_AGE": 10, "PRJ_VOL_DWB": 45.0},
+            {"FEATURE_ID": 102, "PRJ_TOTAL_AGE": 20, "PRJ_VOL_DWB": 90.0},
+            {"FEATURE_ID": 103, "PRJ_TOTAL_AGE": 0, "PRJ_VOL_DWB": 0.0},
+            {"FEATURE_ID": 103, "PRJ_TOTAL_AGE": 10, "PRJ_VOL_DWB": 50.0},
+            {"FEATURE_ID": 103, "PRJ_TOTAL_AGE": 20, "PRJ_VOL_DWB": 95.0},
+            {"FEATURE_ID": 104, "PRJ_TOTAL_AGE": 0, "PRJ_VOL_DWB": 0.0},
+            {"FEATURE_ID": 104, "PRJ_TOTAL_AGE": 10, "PRJ_VOL_DWB": 42.0},
+            {"FEATURE_ID": 104, "PRJ_TOTAL_AGE": 20, "PRJ_VOL_DWB": 88.0},
+        ]
+    ).to_csv(vdyp_yields_csv, index=False)
+
+    def _fake_distribution_plot(**_: object) -> MkrfAuPlotResult:
+        strata_png = output_dir / "strata-tsamkrf.png"
+        strata_pdf = output_dir / "strata-tsamkrf.pdf"
+        output_dir.mkdir(parents=True, exist_ok=True)
+        strata_png.write_bytes(b"png")
+        strata_pdf.write_bytes(b"pdf")
+        return MkrfAuPlotResult(
+            resultant_gdb=tmp_path / "resultant.gdb",
+            assignment_csv=assignment_csv,
+            output_dir=output_dir,
+            png_path=strata_png,
+            pdf_path=strata_pdf,
+            au_count=1,
+            point_count=3,
+            metadata=None,  # type: ignore[arg-type]
+        )
+
+    source_table = pd.DataFrame(
+        [
+            {
+                "FOREST_COVER_ID": 101,
+                "TCL_1_ESTIMATED_SITE_INDEX": 20.0,
+                "AGE_2020": 40.0,
+            },
+            {
+                "FOREST_COVER_ID": 102,
+                "TCL_1_ESTIMATED_SITE_INDEX": 25.0,
+                "AGE_2020": 120.0,
+            },
+            {
+                "FOREST_COVER_ID": 103,
+                "TCL_1_ESTIMATED_SITE_INDEX": 30.0,
+                "AGE_2020": 130.0,
+            },
+        ]
+    )
+
+    monkeypatch.setattr(
+        "mkrf_femic.workflows.mkrf.build_mkrf_au_distribution_plot",
+        _fake_distribution_plot,
+    )
+    monkeypatch.setattr(
+        "mkrf_femic.workflows.mkrf.gpd.read_file", lambda *args, **kwargs: source_table
+    )
+
+    result = build_mkrf_all_plots(
+        resultant_gdb=tmp_path / "resultant.gdb",
+        assignment_csv=assignment_csv,
+        selected_au_csv=selected_au_csv,
+        first_growth_curves_csv=first_growth_curves_csv,
+        managed_curves_csv=managed_curves_csv,
+        vdyp_yields_csv=vdyp_yields_csv,
+        output_dir=output_dir,
+    )
+
+    assert result.lmh_plot_count == 0
+    assert result.fitdiag_plot_count == 0
+
+
+def test_build_mkrf_all_plots_filters_fitdiag_overlay_to_age_eligible_stands(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    assignment_csv = tmp_path / "stand_au_assignment.csv"
+    selected_au_csv = tmp_path / "selected_au_table.csv"
+    first_growth_curves_csv = tmp_path / "first_growth_au_curves.csv"
+    managed_curves_csv = tmp_path / "managed_au_curves.csv"
+    vdyp_yields_csv = tmp_path / "vdyp_yields.csv"
+    output_dir = tmp_path / "plots"
+
+    pd.DataFrame(
+        [
+            {
+                "res_key": 1,
+                "forest_cover_id": 101,
+                "shape_area_ha": 10.0,
+                "au_id": "cwh_dm_x_cw_fdc",
+            },
+            {
+                "res_key": 2,
+                "forest_cover_id": 102,
+                "shape_area_ha": 10.0,
+                "au_id": "cwh_dm_x_cw_fdc",
+            },
+            {
+                "res_key": 3,
+                "forest_cover_id": 103,
+                "shape_area_ha": 10.0,
+                "au_id": "cwh_dm_x_cw_fdc",
+            },
+            {
+                "res_key": 4,
+                "forest_cover_id": 104,
+                "shape_area_ha": 10.0,
+                "au_id": "cwh_dm_x_cw_fdc",
+            },
+        ]
+    ).to_csv(assignment_csv, index=False)
+    pd.DataFrame(
+        [
+            {
+                "au_id": "cwh_dm_x_cw_fdc",
+                "selected_rank": 1,
+                "covered_area_ha": 30.0,
+                "bec_zone": "cwh",
+                "bec_subzone": "dm",
+                "bec_variant": "x",
+                "leading_species_1": "cw",
+                "leading_species_2": "fdc",
+            }
+        ]
+    ).to_csv(selected_au_csv, index=False)
+    pd.DataFrame(
+        [
+            {"au_id": "cwh_dm_x_cw_fdc", "age": 0, "volume": 0.0},
+            {"au_id": "cwh_dm_x_cw_fdc", "age": 10, "volume": 50.0},
+            {"au_id": "cwh_dm_x_cw_fdc", "age": 20, "volume": 100.0},
+        ]
+    ).to_csv(first_growth_curves_csv, index=False)
+    pd.DataFrame(
+        [
+            {
+                "au_id": "cwh_dm_x_cw_fdc",
+                "managed_curve_id": 60001,
+                "age": 0,
+                "volume": 0.0,
+            },
+            {
+                "au_id": "cwh_dm_x_cw_fdc",
+                "managed_curve_id": 60001,
+                "age": 10,
+                "volume": 60.0,
+            },
+            {
+                "au_id": "cwh_dm_x_cw_fdc",
+                "managed_curve_id": 60001,
+                "age": 20,
+                "volume": 110.0,
+            },
+        ]
+    ).to_csv(managed_curves_csv, index=False)
+    pd.DataFrame(
+        [
+            {"FEATURE_ID": 101, "PRJ_TOTAL_AGE": 30, "PRJ_VOL_DWB": 20.0},
+            {"FEATURE_ID": 101, "PRJ_TOTAL_AGE": 40, "PRJ_VOL_DWB": 40.0},
+            {"FEATURE_ID": 101, "PRJ_TOTAL_AGE": 50, "PRJ_VOL_DWB": 85.0},
+            {"FEATURE_ID": 102, "PRJ_TOTAL_AGE": 30, "PRJ_VOL_DWB": 25.0},
+            {"FEATURE_ID": 102, "PRJ_TOTAL_AGE": 40, "PRJ_VOL_DWB": 45.0},
+            {"FEATURE_ID": 102, "PRJ_TOTAL_AGE": 50, "PRJ_VOL_DWB": 90.0},
+            {"FEATURE_ID": 103, "PRJ_TOTAL_AGE": 30, "PRJ_VOL_DWB": 30.0},
+            {"FEATURE_ID": 103, "PRJ_TOTAL_AGE": 40, "PRJ_VOL_DWB": 50.0},
+            {"FEATURE_ID": 103, "PRJ_TOTAL_AGE": 50, "PRJ_VOL_DWB": 95.0},
+            {"FEATURE_ID": 104, "PRJ_TOTAL_AGE": 30, "PRJ_VOL_DWB": 22.0},
+            {"FEATURE_ID": 104, "PRJ_TOTAL_AGE": 40, "PRJ_VOL_DWB": 42.0},
+            {"FEATURE_ID": 104, "PRJ_TOTAL_AGE": 50, "PRJ_VOL_DWB": 88.0},
+        ]
+    ).to_csv(vdyp_yields_csv, index=False)
+
+    def _fake_distribution_plot(**_: object) -> MkrfAuPlotResult:
+        strata_png = output_dir / "strata-tsamkrf.png"
+        strata_pdf = output_dir / "strata-tsamkrf.pdf"
+        output_dir.mkdir(parents=True, exist_ok=True)
+        strata_png.write_bytes(b"png")
+        strata_pdf.write_bytes(b"pdf")
+        return MkrfAuPlotResult(
+            resultant_gdb=tmp_path / "resultant.gdb",
+            assignment_csv=assignment_csv,
+            output_dir=output_dir,
+            png_path=strata_png,
+            pdf_path=strata_pdf,
+            au_count=1,
+            point_count=3,
+            metadata=None,  # type: ignore[arg-type]
+        )
+
+    source_table = pd.DataFrame(
+        [
+            {
+                "FOREST_COVER_ID": 101,
+                "TCL_1_ESTIMATED_SITE_INDEX": 10.0,
+                "AGE_2020": 40.0,
+            },
+            {
+                "FOREST_COVER_ID": 102,
+                "TCL_1_ESTIMATED_SITE_INDEX": 12.0,
+                "AGE_2020": 120.0,
+            },
+            {
+                "FOREST_COVER_ID": 103,
+                "TCL_1_ESTIMATED_SITE_INDEX": 30.0,
+                "AGE_2020": 130.0,
+            },
+            {
+                "FOREST_COVER_ID": 104,
+                "TCL_1_ESTIMATED_SITE_INDEX": 14.0,
+                "AGE_2020": 110.0,
+            },
+        ]
+    )
+
+    captured_feature_ids: list[set[int]] = []
+    original_build_fitdiag_summary = __import__(
+        "mkrf_femic.workflows.mkrf", fromlist=["_build_fitdiag_summary"]
+    )._build_fitdiag_summary
+
+    def _fake_build_first_growth_curves(
+        **_: object,
+    ) -> tuple[pd.DataFrame, pd.DataFrame]:
+        curves = pd.DataFrame(
+            [
+                {"au_id": "cwh_dm_x_cw_fdc__L", "age": 1, "volume": 1.0},
+                {"au_id": "cwh_dm_x_cw_fdc__L", "age": 50, "volume": 80.0},
+                {"au_id": "cwh_dm_x_cw_fdc__L", "age": 100, "volume": 120.0},
+                {"au_id": "cwh_dm_x_cw_fdc__L", "age": 300, "volume": 140.0},
+            ]
+        )
+        diagnostics = pd.DataFrame(
+            [
+                {
+                    "au_id": "cwh_dm_x_cw_fdc__L",
+                    "rmse": 1.0,
+                    "mape": 0.01,
+                    "tail_rmse": 1.0,
+                    "source_stand_count": 2,
+                }
+            ]
+        )
+        return curves, diagnostics
+
+    def _capturing_fitdiag_summary(raw_subset: pd.DataFrame) -> pd.DataFrame:
+        captured_feature_ids.append(set(raw_subset["FEATURE_ID"].astype(int).tolist()))
+        return original_build_fitdiag_summary(raw_subset)
+
+    monkeypatch.setattr(
+        "mkrf_femic.workflows.mkrf.build_mkrf_au_distribution_plot",
+        _fake_distribution_plot,
+    )
+    monkeypatch.setattr(
+        "mkrf_femic.workflows.mkrf.build_mkrf_first_growth_curves",
+        _fake_build_first_growth_curves,
+    )
+    monkeypatch.setattr(
+        "mkrf_femic.workflows.mkrf.gpd.read_file", lambda *args, **kwargs: source_table
+    )
+    monkeypatch.setattr(
+        "mkrf_femic.workflows.mkrf._build_fitdiag_summary", _capturing_fitdiag_summary
+    )
+
+    result = build_mkrf_all_plots(
+        resultant_gdb=tmp_path / "resultant.gdb",
+        assignment_csv=assignment_csv,
+        selected_au_csv=selected_au_csv,
+        first_growth_curves_csv=first_growth_curves_csv,
+        managed_curves_csv=managed_curves_csv,
+        vdyp_yields_csv=vdyp_yields_csv,
+        output_dir=output_dir,
+    )
+
+    assert result.lmh_plot_count == 1
+    assert result.fitdiag_plot_count == 1
+    assert captured_feature_ids == [{102}]

--- a/tests/test_mkrf_runtime_package.py
+++ b/tests/test_mkrf_runtime_package.py
@@ -1,0 +1,644 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from xml.etree import ElementTree as et
+
+import pandas as pd
+import pytest
+
+from mkrf_femic.workflows.mkrf import (
+    _build_unmanaged_species_share_table,
+    _manifest_path_value,
+    audit_mkrf_runtime_sanity,
+    initialize_mkrf_runtime_package,
+)
+
+
+def test_build_unmanaged_species_share_table_aggregates_area_weighted_species_mix() -> (
+    None
+):
+    stand_assignment = pd.DataFrame(
+        [
+            {
+                "forest_cover_id": 1,
+                "au_id": "cwh_vm_1_hw_cw",
+                "shape_area_ha": 10.0,
+                "leading_species_1": "HW",
+                "leading_species_2": "CW",
+                "leading_species_1_share": 60.0,
+                "leading_species_2_share": 30.0,
+            },
+            {
+                "forest_cover_id": 2,
+                "au_id": "cwh_vm_1_hw_cw",
+                "shape_area_ha": 20.0,
+                "leading_species_1": "CW",
+                "leading_species_2": "FD",
+                "leading_species_1_share": 50.0,
+                "leading_species_2_share": 40.0,
+            },
+            {
+                "forest_cover_id": 3,
+                "au_id": "cwh_vm_2_hw_cw",
+                "shape_area_ha": 12.0,
+                "leading_species_1": "ACT",
+                "leading_species_2": "HW",
+                "leading_species_1_share": 55.0,
+                "leading_species_2_share": 25.0,
+            },
+            {
+                "forest_cover_id": 4,
+                "au_id": "outside_selected",
+                "shape_area_ha": 99.0,
+                "leading_species_1": "FD",
+                "leading_species_2": "CW",
+                "leading_species_1_share": 70.0,
+                "leading_species_2_share": 20.0,
+            },
+        ]
+    )
+    selected_au = pd.DataFrame(
+        [
+            {"au_id": "cwh_vm_1_hw_cw"},
+            {"au_id": "cwh_vm_2_hw_cw"},
+        ]
+    )
+
+    result = _build_unmanaged_species_share_table(
+        stand_assignment,
+        selected_au_table=selected_au,
+    ).sort_values("au_id", kind="stable")
+
+    assert result["au_id"].tolist() == ["cwh_vm_1_hw_cw", "cwh_vm_2_hw_cw"]
+
+    first = result.loc[result["au_id"] == "cwh_vm_1_hw_cw"].iloc[0]
+    assert first["share_hw"] == pytest.approx(20.0)
+    assert first["share_cw"] == pytest.approx(43.33, abs=0.01)
+    assert first["share_fd"] == pytest.approx(26.67, abs=0.01)
+    assert first["share_oth"] == pytest.approx(10.0)
+    assert first["share_ba"] == pytest.approx(0.0)
+    assert first["share_dec"] == pytest.approx(0.0)
+    assert first["share_dr"] == pytest.approx(0.0)
+    assert first["share_yc"] == pytest.approx(0.0)
+
+    second = result.loc[result["au_id"] == "cwh_vm_2_hw_cw"].iloc[0]
+    assert second["share_dec"] == pytest.approx(55.0)
+    assert second["share_hw"] == pytest.approx(25.0)
+    assert second["share_oth"] == pytest.approx(20.0)
+    assert second["share_cw"] == pytest.approx(0.0)
+    assert second["share_fd"] == pytest.approx(0.0)
+
+
+def test_initialize_mkrf_runtime_package_writes_manifest(tmp_path: Path) -> None:
+    package_root = tmp_path / "models" / "mkrf_patchworks_model"
+
+    selected_au_csv = tmp_path / "selected_au_table.csv"
+    pd.DataFrame(
+        [
+            {"au_id": "cwh_vm_1_hw_cw"},
+            {"au_id": "cwh_vm_1_dr_hw"},
+        ]
+    ).to_csv(selected_au_csv, index=False)
+
+    stand_origin_assignment_csv = tmp_path / "stand_origin_assignment.csv"
+    pd.DataFrame(
+        [
+            {
+                "forest_cover_id": 101,
+                "au_id": "cwh_vm_1_hw_cw",
+                "origin_class": "fire_origin",
+            },
+            {
+                "forest_cover_id": 102,
+                "au_id": "cwh_vm_1_dr_cw",
+                "origin_class": "logging_origin",
+            },
+        ]
+    ).to_csv(stand_origin_assignment_csv, index=False)
+
+    stand_au_assignment_csv = tmp_path / "stand_au_assignment.csv"
+    pd.DataFrame(
+        [
+            {
+                "forest_cover_id": 101,
+                "au_id": "cwh_vm_1_hw_cw",
+                "shape_area_ha": 10.0,
+                "leading_species_1": "HW",
+                "leading_species_2": "CW",
+                "leading_species_1_share": 60.0,
+                "leading_species_2_share": 30.0,
+            },
+            {
+                "forest_cover_id": 102,
+                "au_id": "cwh_vm_1_dr_cw",
+                "shape_area_ha": 8.0,
+                "leading_species_1": "DR",
+                "leading_species_2": "HW",
+                "leading_species_1_share": 55.0,
+                "leading_species_2_share": 25.0,
+            },
+        ]
+    ).to_csv(stand_au_assignment_csv, index=False)
+
+    managed_bootstrap_csv = tmp_path / "managed_au_bootstrap_table.csv"
+    pd.DataFrame(
+        [
+            {
+                "au_id": "cwh_vm_1_hw_cw",
+                "managed_species_1": "CW",
+                "managed_species_2": "FD",
+                "managed_species_3": "BA",
+                "managed_species_4": "",
+                "managed_species_5": "",
+                "managed_pct_1": 50.0,
+                "managed_pct_2": 30.0,
+                "managed_pct_3": 20.0,
+                "managed_pct_4": 0.0,
+                "managed_pct_5": 0.0,
+                "base_managed_species_1": "CW",
+                "base_managed_species_2": "FD",
+                "base_managed_species_3": "BA",
+                "base_managed_species_4": "",
+                "base_managed_species_5": "",
+                "base_managed_pct_1": 50.0,
+                "base_managed_pct_2": 30.0,
+                "base_managed_pct_3": 20.0,
+                "base_managed_pct_4": 0.0,
+                "base_managed_pct_5": 0.0,
+            },
+            {
+                "au_id": "cwh_vm_1_dr_hw",
+                "managed_species_1": "DR",
+                "managed_species_2": "HW",
+                "managed_species_3": "",
+                "managed_species_4": "",
+                "managed_species_5": "",
+                "managed_pct_1": 60.0,
+                "managed_pct_2": 40.0,
+                "managed_pct_3": 0.0,
+                "managed_pct_4": 0.0,
+                "managed_pct_5": 0.0,
+                "base_managed_species_1": "CW",
+                "base_managed_species_2": "FD",
+                "base_managed_species_3": "PW",
+                "base_managed_species_4": "",
+                "base_managed_species_5": "",
+                "base_managed_pct_1": 45.0,
+                "base_managed_pct_2": 45.0,
+                "base_managed_pct_3": 10.0,
+                "base_managed_pct_4": 0.0,
+                "base_managed_pct_5": 0.0,
+            },
+        ]
+    ).to_csv(managed_bootstrap_csv, index=False)
+
+    first_growth_curves_csv = tmp_path / "first_growth_au_curves.csv"
+    pd.DataFrame(
+        [
+            {"au_id": "cwh_vm_1_hw_cw", "age": 0, "volume": 0.0},
+            {"au_id": "cwh_vm_1_hw_cw", "age": 10, "volume": 12.0},
+        ]
+    ).to_csv(first_growth_curves_csv, index=False)
+
+    first_growth_diagnostics_csv = tmp_path / "first_growth_au_fit_diagnostics.csv"
+    pd.DataFrame(
+        [
+            {"au_id": "cwh_vm_1_hw_cw", "selected_path": "smoothed_bin_pchip"},
+            {"au_id": "cwh_vm_1_dr_hw", "selected_path": "insufficient_source_stands"},
+        ]
+    ).to_csv(first_growth_diagnostics_csv, index=False)
+
+    managed_curves_csv = tmp_path / "managed_au_curves.csv"
+    pd.DataFrame(
+        [
+            {"au_id": "cwh_vm_1_hw_cw", "age": 0, "volume": 0.0},
+            {"au_id": "cwh_vm_1_dr_hw", "age": 0, "volume": 0.0},
+        ]
+    ).to_csv(managed_curves_csv, index=False)
+
+    managed_run_manifest_json = tmp_path / "managed_au_run_manifest.json"
+    managed_run_manifest_json.write_text(
+        json.dumps(
+            {
+                "status": "completed",
+                "curve_au_count": 2,
+                "included_au_count": 2,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    bad_curve_audit_summary_csv = tmp_path / "bad_curve_audit_summary.csv"
+    pd.DataFrame(
+        [
+            {"au_id": "cwh_vm_1_hw_cw", "flagged": False},
+            {"au_id": "cwh_vm_1_dr_hw", "flagged": True},
+        ]
+    ).to_csv(bad_curve_audit_summary_csv, index=False)
+
+    result = initialize_mkrf_runtime_package(
+        package_root=package_root,
+        selected_au_csv=selected_au_csv,
+        stand_origin_assignment_csv=stand_origin_assignment_csv,
+        stand_au_assignment_csv=stand_au_assignment_csv,
+        managed_bootstrap_csv=managed_bootstrap_csv,
+        first_growth_curves_csv=first_growth_curves_csv,
+        first_growth_diagnostics_csv=first_growth_diagnostics_csv,
+        managed_curves_csv=managed_curves_csv,
+        managed_run_manifest_json=managed_run_manifest_json,
+        bad_curve_audit_summary_csv=bad_curve_audit_summary_csv,
+    )
+
+    assert result.package_root == package_root.resolve()
+    assert result.selected_au_count == 2
+    assert result.first_growth_curve_au_count == 1
+    assert result.first_growth_missing_au_count == 1
+    assert result.managed_curve_au_count == 2
+    assert result.manifest_path.exists()
+    assert result.curve_status_path.exists()
+    assert result.analysis_au_runtime_status_path.exists()
+    assert result.analysis_au_curve_refs_path.exists()
+    assert result.runtime_au_remap_audit_path.exists()
+    assert result.species_share_audit_path.exists()
+    assert result.analysis_pin_path.exists()
+    assert result.headless_runtime_common_path.exists()
+    assert result.flow_targets_script_path.exists()
+    assert result.xml_contract_path.exists()
+    assert result.xml_curve_bank_path.exists()
+    assert result.forestmodel_xml_path.exists()
+
+    payload = json.loads(result.manifest_path.read_text(encoding="utf-8"))
+    assert payload["runtime_generation_status"] == "initialized_only"
+    assert payload["counts"]["selected_au_count"] == 2
+    assert payload["counts"]["first_growth_missing_au_count"] == 1
+    assert payload["counts"]["managed_only_runtime_au_count"] == 1
+    assert payload["curve_policy"]["first_growth_borrowing_allowed"] is False
+    assert payload["package_root"] == _manifest_path_value(package_root)
+    assert payload["source_contracts"]["stand_origin_assignment_csv"] == (
+        _manifest_path_value(stand_origin_assignment_csv)
+    )
+    assert payload["source_contracts"]["stand_au_assignment_csv"] == (
+        _manifest_path_value(stand_au_assignment_csv)
+    )
+    assert payload["source_contracts"]["managed_bootstrap_csv"] == (
+        _manifest_path_value(managed_bootstrap_csv)
+    )
+    assert payload["source_contracts"]["runtime_au_remap_audit_csv"] == (
+        _manifest_path_value(result.runtime_au_remap_audit_path)
+    )
+    assert payload["source_contracts"]["runtime_species_share_audit_csv"] == (
+        _manifest_path_value(result.species_share_audit_path)
+    )
+    assert payload["source_contracts"]["analysis_pin"] == _manifest_path_value(
+        result.analysis_pin_path
+    )
+    assert payload["source_contracts"]["headless_runtime_common_bsh"] == (
+        _manifest_path_value(result.headless_runtime_common_path)
+    )
+    assert payload["source_contracts"]["flow_targets_bsh"] == _manifest_path_value(
+        result.flow_targets_script_path
+    )
+    assert (
+        payload["managed_only_runtime_policy"]["insufficient_support_borrowing"]
+        == "forbidden"
+    )
+    assert payload["runtime_au_normalization"]["remapped_source_au_count"] == 1
+
+    xml_root = et.parse(result.xml_contract_path).getroot()
+    source_contracts_node = xml_root.find("sourceContracts")
+    assert source_contracts_node is not None
+    xml_source_contracts = {child.tag: child.text for child in source_contracts_node}
+    assert xml_source_contracts["standOriginAssignmentCsv"] == _manifest_path_value(
+        stand_origin_assignment_csv
+    )
+    assert xml_source_contracts["managedBootstrapCsv"] == _manifest_path_value(
+        managed_bootstrap_csv
+    )
+    assert xml_source_contracts["runtimeCurveStatusCsv"] == _manifest_path_value(
+        result.curve_status_path
+    )
+
+    curve_status = pd.read_csv(result.curve_status_path)
+    assert curve_status["au_id"].tolist() == ["cwh_vm_1_dr_hw", "cwh_vm_1_hw_cw"]
+    assert curve_status["runtime_curve_mode"].tolist() == [
+        "managed_only",
+        "first_growth_and_managed",
+    ]
+    assert curve_status["runtime_curve_note"].fillna("").tolist() == [
+        "insufficient_source_stands_managed_only",
+        "",
+    ]
+
+    tracks_status = pd.read_csv(result.analysis_au_runtime_status_path)
+    assert tracks_status["au_id"].tolist() == ["cwh_vm_1_dr_hw", "cwh_vm_1_hw_cw"]
+    assert tracks_status["runtime_curve_mode"].tolist() == [
+        "managed_only",
+        "first_growth_and_managed",
+    ]
+
+    curve_refs = pd.read_csv(result.analysis_au_curve_refs_path)
+    assert curve_refs["au_id"].tolist() == ["cwh_vm_1_dr_hw", "cwh_vm_1_hw_cw"]
+    assert curve_refs["first_growth_curve_id"].fillna("").tolist() == [
+        "",
+        "FG_CWH_VM_1_HW_CW",
+    ]
+    assert curve_refs["managed_curve_id"].fillna("").tolist() == [
+        "MG_CWH_VM_1_DR_HW",
+        "MG_CWH_VM_1_HW_CW",
+    ]
+
+    remap_audit = pd.read_csv(result.runtime_au_remap_audit_path)
+    assert remap_audit["raw_au_id"].tolist() == ["cwh_vm_1_dr_cw", "cwh_vm_1_hw_cw"]
+    assert remap_audit["au_id"].tolist() == ["cwh_vm_1_dr_hw", "cwh_vm_1_hw_cw"]
+    assert remap_audit["was_remapped"].tolist() == [True, False]
+
+    species_share_audit = pd.read_csv(result.species_share_audit_path)
+    natural_dr = species_share_audit.loc[
+        (species_share_audit["origin_lane"] == "natural")
+        & (species_share_audit["au_id"] == "cwh_vm_1_dr_hw")
+        & (species_share_audit["species_bucket"] == "Dr")
+    ].iloc[0]
+    assert natural_dr["source_name"] == "stand_au_assignment"
+    assert natural_dr["share_pct"] == pytest.approx(55.0)
+    assert natural_dr["share_class"] == "nonzero"
+    treated_hw = species_share_audit.loc[
+        (species_share_audit["origin_lane"] == "treated")
+        & (species_share_audit["au_id"] == "cwh_vm_1_dr_hw")
+        & (species_share_audit["species_bucket"] == "Hw")
+    ].iloc[0]
+    assert treated_hw["source_name"] == "managed_bootstrap"
+    assert treated_hw["share_pct"] == pytest.approx(40.0)
+    assert treated_hw["share_class"] == "nonzero"
+
+    xml_text = result.xml_contract_path.read_text(encoding="utf-8")
+    assert "<mkrfRuntimeCurveContract" in xml_text
+    assert 'runtimeCurveMode="managed_only"' in xml_text
+    assert 'firstGrowthBorrowingAllowed="false"' in xml_text
+
+    curve_bank_text = result.xml_curve_bank_path.read_text(encoding="utf-8")
+    assert "<mkrfRuntimeCurveBank" in curve_bank_text
+    assert (
+        '<analysisUnit id="cwh_vm_1_hw_cw" runtimeCurveMode="first_growth_and_managed">'
+        in curve_bank_text
+    )
+    assert "<firstGrowthCurve" in curve_bank_text
+    assert "<managedCurve>" in curve_bank_text
+
+    forestmodel_text = result.forestmodel_xml_path.read_text(encoding="utf-8")
+    assert "<ForestModel" in forestmodel_text
+    assert "MKRF canonical rebuild" in forestmodel_text
+    assert (
+        '<input block="Int(RES_KEY)" area="Shape_Area/10000" age="Int(AGE_2020)" '
+        "exclude=\"CONTCLAS eq 'X'\" />" in forestmodel_text
+    )
+    assert forestmodel_text.index(
+        'curve id="FG_CWH_VM_1_HW_CW"'
+    ) < forestmodel_text.index('<define field="status"')
+    assert 'curve id="FG_CWH_VM_1_HW_CW"' in forestmodel_text
+    assert 'curve id="MG_CWH_VM_1_DR_HW"' in forestmodel_text
+    assert 'curve id="le10"' in forestmodel_text
+    assert '<define field="status" column="CONTCLAS" />' in forestmodel_text
+    assert (
+        "<define field=\"origin\" column=\"lookupTable(Int(FOREST_COV),'101,102','natural,treated')\" />"
+        in forestmodel_text
+    )
+    assert (
+        '<define field="statecode" column="if(lookupTable(Int(FOREST_COV),\'101,102\','
+        "'natural,treated') eq 'natural','EN','EM')\" />" in forestmodel_text
+    )
+    assert '<define field="au" column="' in forestmodel_text
+    assert (
+        "<define field=\"au\" column=\"lookupTable(Int(FOREST_COV),'101,102','cwh_vm_1_hw_cw,cwh_vm_1_dr_hw')\" />"
+        in forestmodel_text
+    )
+    assert (
+        "<define field=\"auf\" column=\"lookupTable(Int(FOREST_COV),'101,102','cwh_vm_1_hw_cw,cwh_vm_1_dr_hw')\" />"
+        in forestmodel_text
+    )
+
+    analysis_pin_text = result.analysis_pin_path.read_text(encoding="utf-8")
+    assert 'String tracks_path_prefix = "../tracks/";' in analysis_pin_text
+    assert 'sourceRelative("headless_runtime_common.bsh");' in analysis_pin_text
+    assert 'sourceRelative("../scripts/targets/flowtargets.bsh");' in analysis_pin_text
+    assert 'block_shape = "../spatial/fragments.shp";' in analysis_pin_text
+    assert (
+        "setupYieldFlowTargets(control, periods, tracks_path_prefix);"
+        in analysis_pin_text
+    )
+    assert 'def.setCaption("Forest Outline");' in analysis_pin_text
+    assert "new PolygonSymbol(new Color(239, 239, 239))" in analysis_pin_text
+    assert (
+        'ageClassTheme.setFieldname("0.5 * (MANAGEDOFFSET + UNMANAGEDOFFSET)");'
+        in analysis_pin_text
+    )
+    assert 'ageClassTheme.setCaption("Age Class (20-year)");' in analysis_pin_text
+    assert '"age_000_019"' in analysis_pin_text
+    assert '"age_200plus"' in analysis_pin_text
+    assert "new PolygonSymbol(new Color(255, 255, 229))" in analysis_pin_text
+    assert "new PolygonSymbol(new Color(0, 69, 41))" in analysis_pin_text
+    assert 'currTreatTheme.setFieldname("CURRENTTREATMENT");' in analysis_pin_text
+    assert 'latestTreatTheme.setFieldname("LASTTREATMENT");' in analysis_pin_text
+    assert '"CT35"' in analysis_pin_text
+    assert '"CT40"' in analysis_pin_text
+    assert '"CT45"' in analysis_pin_text
+    assert '"CT",' not in analysis_pin_text
+    assert (
+        'patch0Theme.setFieldname("product.area.managed.treat.CC.size");'
+        in analysis_pin_text
+    )
+    assert (
+        'patch1Theme.setFieldname("feature.area.managed.seral.le10.size");'
+        in analysis_pin_text
+    )
+    assert "femicQueueHeadlessStage();" in analysis_pin_text
+
+    headless_common_text = result.headless_runtime_common_path.read_text(
+        encoding="utf-8"
+    )
+    assert "product.yield.managed.total" in headless_common_text
+    assert "flow.even." in headless_common_text
+
+    flow_targets_text = result.flow_targets_script_path.read_text(encoding="utf-8")
+    assert (
+        '_collectAccounts("product.yield.managed.", tracksPathPrefix);'
+        in flow_targets_text
+    )
+    assert (
+        '_collectAccounts("feature.yield.managed.", tracksPathPrefix);'
+        in flow_targets_text
+    )
+    assert '<define field="aux" column="Int(FOREST_COV)" />' in forestmodel_text
+    assert '<define field="hasfg"' not in forestmodel_text
+    assert '<define field="managed" constant="\'C\'" />' in forestmodel_text
+    assert '<attribute label="feature.area.retention.total">' in forestmodel_text
+    assert '<attribute label="%f.area.%m.total">' in forestmodel_text
+    assert '<attribute label="%f.area.%m.seral.le10">' in forestmodel_text
+    assert (
+        "<attribute label=\"'%f.area.%m.state.'+if(startswith(au,'thn'),'THN',statecode)\""
+        in forestmodel_text
+    )
+    assert '<attribute label="%f.yield.%m.total">' in forestmodel_text
+    assert (
+        "<attribute label=\"'%f.yield.%m.state.'+if(startswith(au,'thn'),'THN',statecode)\""
+        in forestmodel_text
+    )
+    assert '<attribute label="%f.yield.%m.merch.total">' in forestmodel_text
+    assert '<attribute label="%f.yield.%m.indsp.Ba">' in forestmodel_text
+    assert '<attribute label="%f.yield.%m.indsp.Cw">' in forestmodel_text
+    assert '<attribute label="%f.yield.%m.indsp.Dr">' in forestmodel_text
+    assert '<attribute label="%f.yield.%m.indsp.Hw">' in forestmodel_text
+    assert 'select statement="status in unmanaged"' in forestmodel_text
+    assert "hasfg eq" not in forestmodel_text
+    assert "startswith(au,'em_')" not in forestmodel_text
+    assert "startswith(au,'thn')" in forestmodel_text
+    assert "substring(au,7)" in forestmodel_text
+    assert forestmodel_text.count('<attribute label="%f.yield.%m.indsp.Ba">') == 2
+    assert forestmodel_text.count('<attribute label="%f.yield.%m.indsp.Cw">') == 2
+    assert forestmodel_text.count('<attribute label="%f.yield.%m.indsp.Dr">') == 2
+    assert forestmodel_text.count('<attribute label="%f.yield.%m.indsp.Hw">') == 2
+    assert "*(" in forestmodel_text
+    assert "<products>" in forestmodel_text
+    assert '<attribute label="product.area.managed.total">' in forestmodel_text
+    assert (
+        "<attribute label=\"'product.area.managed.treat.'+treatment\">"
+        in forestmodel_text
+    )
+    assert '<attribute label="product.yield.managed.total">' in forestmodel_text
+    assert '<attribute label="product.yield.managed.indsp.Ba">' in forestmodel_text
+    assert (
+        "<attribute label=\"'product.yield.managed.treat.'+treatment\">"
+        in forestmodel_text
+    )
+    assert "if(startswith(treatment,'CT'),0," in forestmodel_text
+    assert "/0.45" in forestmodel_text
+    assert "if(startswith(treatment,'CT'),if((" in forestmodel_text
+    assert "if(origin eq 'natural' and hasnatcurve eq 'Y'," in forestmodel_text
+    assert (
+        "lookupTable(treatment+'|'+if(startswith(au,'thn'),substring(au,7),au),"
+        in forestmodel_text
+    )
+    assert (
+        "'CT35|cwh_vm_1_dr_hw,CT40|cwh_vm_1_dr_hw,CT45|cwh_vm_1_dr_hw"
+        in forestmodel_text
+    )
+    assert "CT50|" not in forestmodel_text
+    assert "CT150|" not in forestmodel_text
+    assert "startswith(treatment,'CT')" in forestmodel_text
+    assert "if(startswith(au,'thn'),curveId(" in forestmodel_text
+    assert "),if(startswith(au,'thn'),curveId(" in forestmodel_text
+    assert "if(startswith(au,'thn_'),0.6,1)" not in forestmodel_text
+    assert "if(treatment eq 'CT',0.4,1)" not in forestmodel_text
+    assert '<curve idref="unity"' in forestmodel_text
+    assert '<curve idref="le10"' in forestmodel_text
+    assert (
+        'select statement="status in managed and oper in operable"' in forestmodel_text
+    )
+    assert 'select statement="status in managed"' in forestmodel_text
+    assert "not startswith(au,'thn')" in forestmodel_text
+    assert "share_cw" not in forestmodel_text
+    assert " ge 0.5" in forestmodel_text
+    assert " gt 0.15" not in forestmodel_text
+    assert "'cwh_vm_1_dr_hw,cwh_vm_1_hw_cw','90.0,80.0'" in forestmodel_text
+    assert 'treatment label="CT35" minage="35" maxage="39"' in forestmodel_text
+    assert 'treatment label="CT40" minage="40" maxage="44"' in forestmodel_text
+    assert 'treatment label="CT45" minage="45" maxage="49"' in forestmodel_text
+    assert "'thn040_'+au" in forestmodel_text
+    assert "'thn035_'+au" in forestmodel_text
+    assert "'thn045_'+au" in forestmodel_text
+    assert "'thn050_'+au" not in forestmodel_text
+    assert "'thn150_'+au" not in forestmodel_text
+    assert 'field="statecode" value="\'THN\'"' not in forestmodel_text
+    assert "<track>" in forestmodel_text
+    assert 'treatment label="CC"' in forestmodel_text
+    assert 'treatment label="CT"' not in forestmodel_text
+    assert (
+        'treatment label="CT40" minage="40" maxage="44" retain="20"' in forestmodel_text
+    )
+
+
+def test_audit_mkrf_runtime_sanity_flags_zero_signal_with_nonzero_source_share(
+    tmp_path: Path,
+) -> None:
+    package_root = tmp_path / "models" / "mkrf_patchworks_model"
+    analysis_dir = package_root / "analysis"
+    tracks_dir = package_root / "tracks"
+    analysis_dir.mkdir(parents=True)
+    tracks_dir.mkdir(parents=True)
+
+    pd.DataFrame(
+        [
+            {
+                "origin_lane": "natural",
+                "source_name": "stand_au_assignment",
+                "au_id": "cwh_vm_1_hw_cw",
+                "species_bucket": "Dr",
+                "share_pct": 35.0,
+                "share_class": "nonzero",
+            },
+            {
+                "origin_lane": "treated",
+                "source_name": "managed_bootstrap",
+                "au_id": "cwh_vm_1_hw_cw",
+                "species_bucket": "Hw",
+                "share_pct": 25.0,
+                "share_class": "nonzero",
+            },
+        ]
+    ).to_csv(analysis_dir / "runtime_species_share_audit.csv", index=False)
+
+    pd.DataFrame(
+        [
+            {"ATTRIBUTE": "feature.yield.managed.indsp.Dr"},
+            {"ATTRIBUTE": "product.yield.managed.indsp.Hw"},
+        ]
+    ).to_csv(tracks_dir / "accounts.csv", index=False)
+    pd.DataFrame(
+        [
+            {"ATTRIBUTE": "feature.yield.managed.indsp.Dr"},
+        ]
+    ).to_csv(tracks_dir / "features.csv", index=False)
+    pd.DataFrame(
+        [
+            {"ATTRIBUTE": "product.yield.managed.indsp.Hw"},
+        ]
+    ).to_csv(tracks_dir / "products.csv", index=False)
+
+    stage_dir = tmp_path / "runtime" / "logs" / "headless_stage" / "demo"
+    targets_dir = stage_dir / "targets"
+    targets_dir.mkdir(parents=True)
+    pd.DataFrame(
+        [
+            {"CURRENT": 100.0},
+            {"CURRENT": 150.0},
+        ]
+    ).to_csv(targets_dir / "feature_yield_managed_indsp_Dr.csv", index=False)
+    pd.DataFrame(
+        [
+            {"CURRENT": 0.0},
+            {"CURRENT": 0.0},
+        ]
+    ).to_csv(targets_dir / "product_yield_managed_indsp_Hw.csv", index=False)
+
+    result = audit_mkrf_runtime_sanity(
+        package_root=package_root,
+        stage_dir=stage_dir,
+    )
+
+    assert result.audit_csv_path.exists()
+    assert result.summary_json_path.exists()
+    assert result.row_count == 24
+    assert result.failure_count == 1
+
+    audit_frame = pd.read_csv(result.audit_csv_path)
+    managed_dr = audit_frame.loc[
+        audit_frame["target_label"].eq("feature.yield.managed.indsp.Dr")
+    ].iloc[0]
+    assert managed_dr["target_has_signal"]
+    assert managed_dr["audit_status"] == "pass_signal_matches_source_share"
+
+    managed_hw_product = audit_frame.loc[
+        audit_frame["target_label"].eq("product.yield.managed.indsp.Hw")
+    ].iloc[0]
+    assert not managed_hw_product["target_has_signal"]
+    assert managed_hw_product["audit_status"] == "fail_zero_signal_with_source_share"

--- a/tests/test_mkrf_runtime_spatial.py
+++ b/tests/test_mkrf_runtime_spatial.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import geopandas as gpd
+from shapely.geometry import Polygon
+
+from mkrf_femic.workflows.mkrf import _project_mkrf_runtime_fragments
+
+
+def test_project_mkrf_runtime_fragments_filters_x_and_projects_fields() -> None:
+    source_gdf = gpd.GeoDataFrame(
+        {
+            "FOREST_COVER_ID": [9001, 9002],
+            "Operability": ["Operable", "Low Operability"],
+            "Shape_Length": [10.0, 20.0],
+            "Shape_Area": [100.0, 200.0],
+            "CONTCLAS": ["C", "X"],
+            "AGE_2020": [80, 15],
+            "AU_EX": ["1", "2"],
+            "AU_FU": ["1", "2"],
+            "RES_KEY": [101, 102],
+            "CT_eligib": ["N", "Y"],
+        },
+        geometry=[
+            Polygon([(0, 0), (1, 0), (1, 1), (0, 1)]),
+            Polygon([(2, 0), (3, 0), (3, 1), (2, 1)]),
+        ],
+        crs="EPSG:3005",
+    )
+
+    out = _project_mkrf_runtime_fragments(source_gdf=source_gdf)
+
+    assert len(out) == 1
+    assert out.columns.tolist() == [
+        "FOREST_COV",
+        "Operabilit",
+        "Shape_Leng",
+        "Shape_Area",
+        "CONTCLAS",
+        "AGE_2020",
+        "AU_EX",
+        "AU_FU",
+        "RES_KEY",
+        "CT_eligib",
+        "geometry",
+    ]
+    row = out.iloc[0]
+    assert row["FOREST_COV"] == 9001
+    assert row["Operabilit"] == "Operable"
+    assert row["Shape_Leng"] == 10.0
+    assert row["RES_KEY"] == 101
+    assert row["CONTCLAS"] == "C"


### PR DESCRIPTION
﻿## Summary
- add installable `mkrf_femic` package for MKRF-owned FEMIC workflow implementation
- add `python -m mkrf_femic` and `mkrf-femic` command surfaces replacing parent `femic instance mkrf-*` usage
- move MKRF pipeline/workflow tests into this repo and update `mkrf_freshforge` to call `python -m mkrf_femic ...`
- update README/operator/rebuild docs to describe instance-owned execution backend

## Verification
- `python -m pip install -e .[dev]`
- `python -m ruff format src tests`
- `python -m ruff check src tests`
- `python -m pytest -q` (`59 passed, 4 skipped`; skips are legacy review extracts not materialized locally)
- `python -m mkrf_femic --help`
- `mkrf-femic --help`
- `freshforge providers --json`
- `freshforge validate workflows/freshforge/mkrf_model_build_workflow.yaml --json`
- `freshforge plan workflows/freshforge/mkrf_model_build_workflow.yaml --json`
- `freshforge run workflows/freshforge/mkrf_model_build_workflow.yaml --run-id p86_dry_run --dry-run --json`
- `sphinx-build -b html docs _build/html -W`
- `python -m build`
- `twine check dist/*`
- inspected wheel metadata: `console_scripts` contains `mkrf-femic`; `freshforge.providers` contains `mkrf`

Closes #42.
