### PR TITLE
P92M: Own MKRF Patchworks variant registry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ authors = [
     {name = "UBC FRESH Lab"},
 ]
 dependencies = [
+    "PyYAML>=6",
     "rich",
     "typer",
 ]
@@ -23,6 +24,9 @@ mkrf-femic = "mkrf_femic.cli:app"
 [project.entry-points."freshforge.providers"]
 mkrf = "mkrf_freshforge:provider_factory"
 
+[project.entry-points."femic.patchworks_variant_registries"]
+mkrf = "mkrf_femic.patchworks_variants:provider_factory"
+
 [project.optional-dependencies]
 dev = [
     "pytest",
@@ -30,6 +34,9 @@ dev = [
 
 [tool.setuptools]
 package-dir = {"" = "src"}
+
+[tool.setuptools.package-data]
+mkrf_femic = ["resources/*.yaml"]
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/mkrf_femic/patchworks_variants.py
+++ b/src/mkrf_femic/patchworks_variants.py
@@ -1,0 +1,37 @@
+"""MKRF-owned Patchworks variant registry provider."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from importlib import resources
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+@dataclass(frozen=True)
+class MkrfPatchworksVariantRegistryProvider:
+    """Expose MKRF Patchworks variants to FEMIC through entry-point discovery."""
+
+    provider_id: str = "mkrf"
+    registry_base_dir: Path = field(
+        default_factory=lambda: Path(__file__).resolve().parents[2]
+    )
+
+    def load_registry_payload(self) -> dict[str, Any]:
+        resource = resources.files("mkrf_femic.resources").joinpath(
+            "patchworks_variants.yaml"
+        )
+        payload = yaml.safe_load(resource.read_text(encoding="utf-8"))
+        if not isinstance(payload, dict):
+            raise ValueError(
+                "MKRF Patchworks variant registry payload must be a mapping."
+            )
+        return payload
+
+
+def provider_factory() -> MkrfPatchworksVariantRegistryProvider:
+    """Return the MKRF Patchworks variant registry provider."""
+
+    return MkrfPatchworksVariantRegistryProvider()

--- a/src/mkrf_femic/resources/__init__.py
+++ b/src/mkrf_femic/resources/__init__.py
@@ -1,0 +1,1 @@
+"""Packaged MKRF registry resources."""

--- a/src/mkrf_femic/resources/patchworks_variants.yaml
+++ b/src/mkrf_femic/resources/patchworks_variants.yaml
@@ -1,0 +1,35 @@
+instances:
+- instance_id: mkrf
+  label: MKRF canonical rebuild instance
+variants:
+- variant_id: mkrf.base
+  label: MKRF canonical rebuild base
+  instance_id: mkrf
+  variant_family: baseline
+  kind: patchworks
+  instance_root: .
+  analysis_pin: models/mkrf_patchworks_model/analysis/base.pin
+  runtime_config: config/patchworks.runtime.mkrf_rebuild.windows.yaml
+  default: true
+  default_scenario_id: even_flow_smoke
+  notes:
+  - Canonical MKRF rebuild launch surface backed by the FEMIC-native runtime package.
+  scenarios:
+  - scenario_id: even_flow_smoke
+    label: MKRF base even-flow smoke
+    mode: max-even-flow-smoke
+    target: product.yield.managed.total
+    iterations: 100000
+    improvement: 0.0
+- variant_id: mkrf.poc_base
+  label: MKRF PoC base
+  instance_id: mkrf
+  variant_family: benchmark
+  kind: patchworks
+  instance_root: .
+  analysis_pin: models/mkrf_patchworks_model_poc/analysis/base.pin
+  runtime_config: config/patchworks.runtime.windows.yaml
+  notes:
+  - Retained PoC benchmark launch surface backed by the older checkpoint-oriented
+    control lane.
+scenario_sets: []

--- a/tests/test_patchworks_variants.py
+++ b/tests/test_patchworks_variants.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from importlib import metadata
+from pathlib import Path
+
+from mkrf_femic.patchworks_variants import provider_factory
+
+
+def test_patchworks_variant_provider_metadata() -> None:
+    provider = provider_factory()
+
+    assert provider.provider_id == "mkrf"
+    assert provider.registry_base_dir == Path(__file__).resolve().parents[1]
+
+    payload = provider.load_registry_payload()
+    assert payload["instances"][0]["instance_id"] == "mkrf"
+    variant_ids = {item["variant_id"] for item in payload["variants"]}
+    assert variant_ids == {"mkrf.base", "mkrf.poc_base"}
+    base = next(
+        item for item in payload["variants"] if item["variant_id"] == "mkrf.base"
+    )
+    assert base["instance_root"] == "."
+    assert base["analysis_pin"] == "models/mkrf_patchworks_model/analysis/base.pin"
+    assert (
+        base["runtime_config"] == "config/patchworks.runtime.mkrf_rebuild.windows.yaml"
+    )
+
+
+def test_package_exposes_patchworks_variant_registry_entry_point() -> None:
+    entry_points = metadata.entry_points().select(
+        group="femic.patchworks_variant_registries"
+    )
+    matches = [
+        entry_point for entry_point in entry_points if entry_point.name == "mkrf"
+    ]
+    assert matches
+    assert matches[0].value == "mkrf_femic.patchworks_variants:provider_factory"


### PR DESCRIPTION
## Summary

- expose the MKRF Patchworks variant registry through `femic.patchworks_variant_registries`
- move MKRF variant definitions into package data under `mkrf_femic`
- add provider metadata and entry-point tests

Parent FEMIC issue: UBC-FRESH/femic#252
MKRF issue: #46

## Validation

- `python -m pip install -e .[dev]`
- `ruff check src tests`
- `pytest tests/test_patchworks_variants.py`
