### PR TITLE
Add FreshForge materialization overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,10 @@ Current primary runtime/package references:
 ## FreshForge Workflow Contract
 
 This instance owns the concrete FreshForge workflow document for the MKRF
-canonical rebuild lane:
+canonical rebuild lane and a parent-checkout materialization workflow:
 
 - `workflows/freshforge/mkrf_model_build_workflow.yaml`
+- `workflows/freshforge/mkrf_materialization_workflow.yaml`
 
 FreshForge is the declarative workflow and explicit execution surface here. It
 can list the FEMIC and MKRF providers, validate the MKRF graph, inspect provider
@@ -92,15 +93,30 @@ freshforge providers
 freshforge validate workflows/freshforge/mkrf_model_build_workflow.yaml
 freshforge inspect workflows/freshforge/mkrf_model_build_workflow.yaml
 freshforge plan workflows/freshforge/mkrf_model_build_workflow.yaml
-freshforge run workflows/freshforge/mkrf_model_build_workflow.yaml --run-id mkrf_freshforge_exec --report runtime/freshforge/runs/mkrf_freshforge_exec.json
+freshforge run workflows/freshforge/mkrf_model_build_workflow.yaml --workdir runtime/freshforge --namespace mkrf/model-build --json
 ```
 
 `validate`, `inspect`, and `plan` are non-mutating. `run` launches provider-owned
 FEMIC commands in the planned order, including BTC and Patchworks Matrix Builder.
-FreshForge still does not materialize DataLad content or inspect declared
-artifact files in this phase. Use `config/rebuild.spec.yaml` and
-`femic instance rebuild --dry-run` as the legacy execution dry-run comparison
-surface.
+Use `freshforge plan` as the non-mutating preview. Use
+`config/rebuild.spec.yaml` and `femic instance rebuild --dry-run` as the legacy
+execution dry-run comparison surface.
+
+For parent-checkout materialization, run these commands from the parent FEMIC
+repository root:
+
+```bash
+freshforge providers
+freshforge validate external/femic-mkrf-instance/workflows/freshforge/mkrf_materialization_workflow.yaml
+freshforge inspect external/femic-mkrf-instance/workflows/freshforge/mkrf_materialization_workflow.yaml
+freshforge plan external/femic-mkrf-instance/workflows/freshforge/mkrf_materialization_workflow.yaml
+freshforge run external/femic-mkrf-instance/workflows/freshforge/mkrf_materialization_workflow.yaml --workdir runtime/freshforge --namespace mkrf/materialization --json
+```
+
+`freshforge run` for the materialization workflow performs real submodule,
+package-install, DataLad, and git-annex work. It materializes the MKRF
+`models`, `config`, `workflows`, and `data/source` paths and writes an ignored
+report under the parent checkout `runtime/freshforge/` tree.
 
 The first MKRF node validates `config/rebuild.spec.yaml` through
 `femic instance validate-spec`; the older TSA-style `femic prep validate-case`,

--- a/docs/operator-runbook.rst
+++ b/docs/operator-runbook.rst
@@ -16,13 +16,25 @@ Minimal Operator Path
 2. Run the FreshForge workflow only when the local environment is ready for
    FEMIC, BTC, and Patchworks:
 
-   - ``freshforge run workflows/freshforge/mkrf_model_build_workflow.yaml --run-id mkrf_freshforge_exec --report runtime/freshforge/runs/mkrf_freshforge_exec.json``
+   - ``freshforge run workflows/freshforge/mkrf_model_build_workflow.yaml --workdir runtime/freshforge --namespace mkrf/model-build --json``
 
    ``freshforge run`` launches provider-owned FEMIC commands in planned order.
    The current executable graph uses the MKRF-owned runtime-package
    regeneration commands after geospatial preflight rather than the older
    TSA-style ``femic run`` and BTC/post-TIPSY lane. It does not materialize
    DataLad content or inspect declared artifact files in this phase.
+
+   If the MKRF submodule is thin or missing annexed content, run the
+   materialization workflow first from the parent FEMIC checkout:
+
+   - ``freshforge validate external/femic-mkrf-instance/workflows/freshforge/mkrf_materialization_workflow.yaml``
+   - ``freshforge inspect external/femic-mkrf-instance/workflows/freshforge/mkrf_materialization_workflow.yaml``
+   - ``freshforge plan external/femic-mkrf-instance/workflows/freshforge/mkrf_materialization_workflow.yaml``
+   - ``freshforge run external/femic-mkrf-instance/workflows/freshforge/mkrf_materialization_workflow.yaml --workdir runtime/freshforge --namespace mkrf/materialization --json``
+
+   ``freshforge plan`` is the non-mutating preview. The materialization
+   ``freshforge run`` performs real submodule, package-install, DataLad, and
+   git-annex work.
 
 3. Validate the instance spec:
 

--- a/docs/rebuild-and-qa.rst
+++ b/docs/rebuild-and-qa.rst
@@ -23,7 +23,11 @@ Core Validation Surfaces
 - ``freshforge validate workflows/freshforge/mkrf_model_build_workflow.yaml``
 - ``freshforge inspect workflows/freshforge/mkrf_model_build_workflow.yaml``
 - ``freshforge plan workflows/freshforge/mkrf_model_build_workflow.yaml``
-- ``freshforge run workflows/freshforge/mkrf_model_build_workflow.yaml --run-id mkrf_freshforge_exec --report runtime/freshforge/runs/mkrf_freshforge_exec.json``
+- ``freshforge run workflows/freshforge/mkrf_model_build_workflow.yaml --workdir runtime/freshforge --namespace mkrf/model-build --json``
+- ``freshforge validate external/femic-mkrf-instance/workflows/freshforge/mkrf_materialization_workflow.yaml``
+- ``freshforge inspect external/femic-mkrf-instance/workflows/freshforge/mkrf_materialization_workflow.yaml``
+- ``freshforge plan external/femic-mkrf-instance/workflows/freshforge/mkrf_materialization_workflow.yaml``
+- ``freshforge run external/femic-mkrf-instance/workflows/freshforge/mkrf_materialization_workflow.yaml --workdir runtime/freshforge --namespace mkrf/materialization --json``
 - runtime XML under ``models/mkrf_patchworks_model/xml/``
 - runtime tracks under ``models/mkrf_patchworks_model/tracks/``
 - runtime spatial under ``models/mkrf_patchworks_model/spatial/``
@@ -60,10 +64,12 @@ references, MKRF-owned configuration paths, and declared runtime artifacts.
 FreshForge validation, inspection, and planning are non-mutating. FreshForge
 ``run`` explicitly launches provider-owned FEMIC commands in planned order,
 including the MKRF-owned runtime-package regeneration commands and Patchworks
-Matrix Builder. FreshForge still does not materialize DataLad content or read
-declared artifact files in this phase. The current MKRF executable graph does
-not use the older TSA-style ``femic run`` and BTC/post-TIPSY nodes because those
-still require legacy checkpoint files outside the accepted MKRF source contract.
+Matrix Builder. FreshForge materialization is a separate workflow that can
+prepare a thin parent checkout by initializing the MKRF submodule, installing
+dependencies, enabling ``arbutus-s3``, materializing required MKRF paths, and
+writing an ignored report. The current MKRF executable graph does not use the
+older TSA-style ``femic run`` and BTC/post-TIPSY nodes because those still
+require legacy checkpoint files outside the accepted MKRF source contract.
 ``femic instance rebuild --dry-run`` remains the legacy execution dry-run
 comparison surface for ``config/rebuild.spec.yaml``.
 

--- a/planning/freshforge_materialization_overlay.md
+++ b/planning/freshforge_materialization_overlay.md
@@ -1,0 +1,26 @@
+# MKRF FreshForge Materialization Overlay
+
+This note records the MKRF-owned materialization overlay added for FEMIC P101.
+The workflow is meant to be run from the parent FEMIC checkout with MKRF mounted
+as `external/femic-mkrf-instance`.
+
+MKRF uses the generic FEMIC materialization provider:
+
+- `femic.materialization.check_toolchain`
+- `femic.materialization.check_python_environment`
+- `femic.materialization.install_packages`
+- `femic.materialization.init_submodules`
+- `femic.materialization.init_annex`
+- `femic.materialization.enable_special_remote`
+- `femic.materialization.materialize_paths`
+- `femic.materialization.audit_annex_availability`
+- `femic.materialization.write_materialization_report`
+
+The overlay materializes `models`, `config`, `workflows`, and `data/source`.
+Those paths cover the current canonical runtime package plus the source FileGDB
+used by the MKRF model-build workflow. The report is written under
+`runtime/freshforge/`, which is ignored.
+
+The install step includes the parent FEMIC `dev` and `freshforge` extras and
+installs this MKRF repository editable. That makes the MKRF-owned `mkrf`
+FreshForge provider available for later model-build workflow commands.

--- a/runbooks/REBUILD_RUNBOOK.md
+++ b/runbooks/REBUILD_RUNBOOK.md
@@ -19,6 +19,7 @@ companion to that docs surface, not as a replacement for it.
 The instance-owned FreshForge graph is:
 
 - `workflows/freshforge/mkrf_model_build_workflow.yaml`
+- `workflows/freshforge/mkrf_materialization_workflow.yaml`
 
 Use it to validate, inspect, and plan the rebuild graph before execution:
 
@@ -31,16 +32,34 @@ Use it to validate, inspect, and plan the rebuild graph before execution:
 Run it explicitly only when the local environment is ready for FEMIC, BTC, and
 Patchworks:
 
-6. `freshforge run workflows/freshforge/mkrf_model_build_workflow.yaml --run-id mkrf_freshforge_exec --report runtime/freshforge/runs/mkrf_freshforge_exec.json`
+6. `freshforge run workflows/freshforge/mkrf_model_build_workflow.yaml --workdir runtime/freshforge --namespace mkrf/model-build --json`
 
 FreshForge `validate`, `inspect`, and `plan` are non-mutating. FreshForge `run`
 launches provider-owned FEMIC commands in planned order. The current executable
 graph uses the MKRF-owned runtime-package regeneration commands after
 geospatial preflight; older TSA-style `femic run` and BTC/post-TIPSY nodes still
 require legacy checkpoint files outside the accepted MKRF source contract. It
-still does not materialize DataLad content or inspect declared artifact files in
-this phase. `config/rebuild.spec.yaml` and `femic instance rebuild --dry-run`
-remain the legacy dry-run comparison surface.
+does not materialize DataLad content; use the materialization workflow first
+from the parent checkout when starting from a thin clone.
+`config/rebuild.spec.yaml` and `femic instance rebuild --dry-run` remain the
+legacy dry-run comparison surface.
+
+## FreshForge materialization workflow
+
+Run the materialization workflow from the parent FEMIC checkout, not from inside
+the MKRF submodule:
+
+1. `freshforge providers`
+2. `freshforge validate external/femic-mkrf-instance/workflows/freshforge/mkrf_materialization_workflow.yaml`
+3. `freshforge inspect external/femic-mkrf-instance/workflows/freshforge/mkrf_materialization_workflow.yaml`
+4. `freshforge plan external/femic-mkrf-instance/workflows/freshforge/mkrf_materialization_workflow.yaml`
+5. `freshforge run external/femic-mkrf-instance/workflows/freshforge/mkrf_materialization_workflow.yaml --workdir runtime/freshforge --namespace mkrf/materialization --json`
+
+FreshForge `plan` is the non-mutating preview. FreshForge `run` performs real
+submodule, package-install, DataLad, and git-annex work. The current MKRF
+overlay materializes `models`, `config`, `workflows`, and `data/source`, audits
+`models` and `data/source` against `arbutus-s3`, and writes an ignored report
+under the parent checkout `runtime/freshforge/` tree.
 
 The MKRF-specific FreshForge nodes use the `mkrf.*` provider namespace from this
 instance adapter. FEMIC core still supplies reusable `femic.*` nodes, while the

--- a/workflows/freshforge/mkrf_materialization_overlay.yaml
+++ b/workflows/freshforge/mkrf_materialization_overlay.yaml
@@ -1,0 +1,27 @@
+instance:
+  root: external/femic-mkrf-instance
+  submodule_path: external/femic-mkrf-instance
+environment:
+  venv_path: .venv
+install:
+  extras:
+    - dev
+    - freshforge
+  requirements: []
+  editable_paths:
+    - external/femic-mkrf-instance
+  packages: []
+annex:
+  special_remote: arbutus-s3
+materialization:
+  required_paths:
+    - models
+    - config
+    - workflows
+    - data/source
+audit:
+  required_paths:
+    - models
+    - data/source
+report:
+  path: runtime/freshforge/mkrf_materialization_report.json

--- a/workflows/freshforge/mkrf_materialization_workflow.yaml
+++ b/workflows/freshforge/mkrf_materialization_workflow.yaml
@@ -1,0 +1,93 @@
+workflow:
+  id: mkrf_materialization
+  name: MKRF FreshForge materialization workflow
+  description: Parent-checkout FreshForge graph for materializing the MKRF model instance with the generic FEMIC materialization provider.
+nodes:
+  - id: check_toolchain
+    provider: femic.materialization.check_toolchain
+    outputs:
+      toolchain: toolchain_ok
+    parameters:
+      overlay: external/femic-mkrf-instance/workflows/freshforge/mkrf_materialization_overlay.yaml
+  - id: check_python_environment
+    provider: femic.materialization.check_python_environment
+    needs:
+      - check_toolchain
+    inputs:
+      toolchain: check_toolchain.toolchain
+    outputs:
+      python_environment: python_environment_ok
+    parameters:
+      overlay: external/femic-mkrf-instance/workflows/freshforge/mkrf_materialization_overlay.yaml
+  - id: install_packages
+    provider: femic.materialization.install_packages
+    needs:
+      - check_python_environment
+    inputs:
+      python_environment: check_python_environment.python_environment
+    outputs:
+      packages: packages_installed
+    parameters:
+      overlay: external/femic-mkrf-instance/workflows/freshforge/mkrf_materialization_overlay.yaml
+  - id: init_submodules
+    provider: femic.materialization.init_submodules
+    needs:
+      - install_packages
+    inputs:
+      packages: install_packages.packages
+    outputs:
+      submodules: submodules_initialized
+    parameters:
+      overlay: external/femic-mkrf-instance/workflows/freshforge/mkrf_materialization_overlay.yaml
+  - id: init_annex
+    provider: femic.materialization.init_annex
+    needs:
+      - init_submodules
+    inputs:
+      submodules: init_submodules.submodules
+    outputs:
+      annex_repository: annex_initialized
+    parameters:
+      overlay: external/femic-mkrf-instance/workflows/freshforge/mkrf_materialization_overlay.yaml
+  - id: enable_special_remote
+    provider: femic.materialization.enable_special_remote
+    needs:
+      - init_annex
+    inputs:
+      annex_repository: init_annex.annex_repository
+    outputs:
+      special_remote: arbutus_s3_enabled
+    parameters:
+      overlay: external/femic-mkrf-instance/workflows/freshforge/mkrf_materialization_overlay.yaml
+  - id: materialize_paths
+    provider: femic.materialization.materialize_paths
+    needs:
+      - enable_special_remote
+    inputs:
+      special_remote: enable_special_remote.special_remote
+    outputs:
+      materialized_paths: mkrf_materialized_paths
+    parameters:
+      overlay: external/femic-mkrf-instance/workflows/freshforge/mkrf_materialization_overlay.yaml
+  - id: audit_annex_availability
+    provider: femic.materialization.audit_annex_availability
+    needs:
+      - materialize_paths
+    inputs:
+      materialized_paths: materialize_paths.materialized_paths
+    outputs:
+      annex_audit: annex_availability_ok
+    parameters:
+      overlay: external/femic-mkrf-instance/workflows/freshforge/mkrf_materialization_overlay.yaml
+  - id: write_materialization_report
+    provider: femic.materialization.write_materialization_report
+    needs:
+      - audit_annex_availability
+    inputs:
+      annex_audit: audit_annex_availability.annex_audit
+    outputs:
+      materialization_report: mkrf_materialization_report
+    parameters:
+      overlay: external/femic-mkrf-instance/workflows/freshforge/mkrf_materialization_overlay.yaml
+    artifacts:
+      report: runtime/freshforge/mkrf_materialization_report.json


### PR DESCRIPTION
Closes #48.

## Summary
- adds MKRF-owned FreshForge materialization overlay and workflow files
- documents the parent-checkout materialization command sequence
- updates stale MKRF FreshForge model-build run examples from branch-era `--run-id` / `--report` flags to released `--workdir` / `--namespace` usage
- keeps runtime reports under ignored `runtime/freshforge/`

## Validation
- `freshforge providers --json` lists `femic.materialization` and `mkrf`
- `freshforge validate external/femic-mkrf-instance/workflows/freshforge/mkrf_materialization_workflow.yaml --json` -> ok
- `freshforge inspect external/femic-mkrf-instance/workflows/freshforge/mkrf_materialization_workflow.yaml --json` -> ok
- `freshforge plan external/femic-mkrf-instance/workflows/freshforge/mkrf_materialization_workflow.yaml --json` -> ok
- `freshforge run external/femic-mkrf-instance/workflows/freshforge/mkrf_materialization_workflow.yaml --workdir runtime/freshforge --namespace mkrf/materialization --json` -> all 9 nodes success
- `git -C external/femic-mkrf-instance annex find --not --in arbutus-s3 -- models data/source` -> no payload gaps reported
- `sphinx-build -b html external/femic-mkrf-instance/docs external/femic-mkrf-instance/docs/_build/html -W` -> passed
