### PR TITLE
P106: executable MKRF FreshForge model-build acceptance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ plots/*
 !plots/vdyp_fitdiag_tsamkrf-*.png
 !plots/tipsy_vdyp_tsamkrf-*.png
 docs/_build/
+_build/
 
 # Legacy intermediate artifacts
 data/*.feather

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .venv/
 __pycache__/
 *.pyc
+*.egg-info/
 
 # Runtime logs and manifests
 runtime/logs/

--- a/README.md
+++ b/README.md
@@ -81,19 +81,36 @@ canonical rebuild lane and a parent-checkout materialization workflow:
 FreshForge is the declarative workflow and explicit execution surface here. It
 can list the FEMIC and MKRF providers, validate the MKRF graph, inspect provider
 references, produce a deterministic plan, and run the workflow when requested.
-Install the instance-owned adapter from this repository before using the
-workflow:
+Install the parent FEMIC package with FreshForge support and this
+instance-owned adapter before using the workflow:
 
 ```bash
-python -m pip install -e .
+python -m pip install -e ".[dev,freshforge]"
+python -m pip install -e external/femic-mkrf-instance
 ```
+
+From the parent FEMIC checkout, discover and render the available workflow
+commands:
+
+```bash
+python -m femic freshforge workflows list
+python -m femic freshforge workflows commands external/femic-mkrf-instance/workflows/freshforge/mkrf_model_build_workflow.yaml
+```
+
+Run the rebuild-spec validation as a separate pre-run check:
+
+```bash
+python -m femic instance validate-spec --instance-root external/femic-mkrf-instance --spec config/rebuild.spec.yaml
+```
+
+Then validate, preview, and explicitly run the FreshForge model-build workflow:
 
 ```bash
 freshforge providers
-freshforge validate workflows/freshforge/mkrf_model_build_workflow.yaml
-freshforge inspect workflows/freshforge/mkrf_model_build_workflow.yaml
-freshforge plan workflows/freshforge/mkrf_model_build_workflow.yaml
-freshforge run workflows/freshforge/mkrf_model_build_workflow.yaml --workdir runtime/freshforge --namespace mkrf/model-build --json
+freshforge validate external/femic-mkrf-instance/workflows/freshforge/mkrf_model_build_workflow.yaml
+freshforge inspect external/femic-mkrf-instance/workflows/freshforge/mkrf_model_build_workflow.yaml
+freshforge plan external/femic-mkrf-instance/workflows/freshforge/mkrf_model_build_workflow.yaml
+freshforge run external/femic-mkrf-instance/workflows/freshforge/mkrf_model_build_workflow.yaml --workdir runtime/freshforge --namespace mkrf/model-build --json
 ```
 
 `validate`, `inspect`, and `plan` are non-mutating. `run` launches provider-owned
@@ -118,14 +135,12 @@ package-install, DataLad, and git-annex work. It materializes the MKRF
 `models`, `config`, `workflows`, and `data/source` paths and writes an ignored
 report under the parent checkout `runtime/freshforge/` tree.
 
-The first MKRF node validates `config/rebuild.spec.yaml` through
-`femic instance validate-spec`; the older TSA-style `femic prep validate-case`,
-`femic run`, and BTC/post-TIPSY surfaces still require legacy checkpoint files
-that are not part of the current MKRF accepted source contract. The executable
-MKRF graph therefore starts its regeneration lane at the MKRF-owned
-`mkrf.*` provider nodes after geospatial preflight. Those nodes are owned by
-the adapter package in this instance repository and delegate to the
-instance-owned `python -m mkrf_femic ...` commands.
+Rebuild-spec validation remains a separate pre-run FEMIC check. The first
+FreshForge node runs generic case preflight, then the executable MKRF graph
+starts its regeneration lane at the MKRF-owned `mkrf.*` provider nodes after
+geospatial preflight. Those nodes are owned by the adapter package in this
+instance repository and delegate to the instance-owned
+`python -m mkrf_femic ...` commands.
 
 ## Project Communication Surfaces
 
@@ -332,9 +347,9 @@ Policy:
 ## Quickstart
 
 1. Validate the rebuild contract:
-   `femic instance validate-spec --spec config/rebuild.spec.yaml`
+   `python -m femic instance validate-spec --instance-root external/femic-mkrf-instance --spec config/rebuild.spec.yaml`
 2. Dry-run the rebuild sequence:
-   `femic instance rebuild --spec config/rebuild.spec.yaml --dry-run --run-id mkrf_dryrun`
+   `python -m femic instance rebuild --instance-root external/femic-mkrf-instance --spec config/rebuild.spec.yaml --dry-run --run-id mkrf_dryrun`
 3. Review the legacy compiled-package reference note:
    `runbooks/LEGACY_COMPILED_PACKAGE_REFERENCE.md`
 4. Review the legacy XML-builder authority note:

--- a/README.md
+++ b/README.md
@@ -135,11 +135,12 @@ package-install, DataLad, and git-annex work. It materializes the MKRF
 `models`, `config`, `workflows`, and `data/source` paths and writes an ignored
 report under the parent checkout `runtime/freshforge/` tree.
 
-Rebuild-spec validation remains a separate pre-run FEMIC check. The first
-FreshForge node runs generic case preflight, then the executable MKRF graph
-starts its regeneration lane at the MKRF-owned `mkrf.*` provider nodes after
-geospatial preflight. Those nodes are owned by the adapter package in this
-instance repository and delegate to the instance-owned
+Rebuild-spec validation remains a separate pre-run FEMIC check. The executable
+MKRF graph starts its regeneration lane at the MKRF-owned `mkrf.*` provider
+nodes because the older TSA-style case/geospatial preflight surfaces require
+legacy checkpoint files outside the current MKRF accepted source contract.
+Those nodes are owned by the adapter package in this instance repository and
+delegate to the instance-owned
 `python -m mkrf_femic ...` commands.
 
 ## Project Communication Surfaces

--- a/docs/operator-runbook.rst
+++ b/docs/operator-runbook.rst
@@ -25,9 +25,9 @@ Minimal Operator Path
    - ``freshforge run external/femic-mkrf-instance/workflows/freshforge/mkrf_model_build_workflow.yaml --workdir runtime/freshforge --namespace mkrf/model-build --json``
 
    ``freshforge run`` launches provider-owned FEMIC commands in planned order.
-   The current executable graph uses the MKRF-owned runtime-package
-   regeneration commands after geospatial preflight rather than the older
-   TSA-style ``femic run`` and BTC/post-TIPSY lane. It does not materialize
+   The current executable graph starts with the MKRF-owned runtime-package
+   regeneration commands rather than the older TSA-style case/geospatial
+   preflight, ``femic run``, and BTC/post-TIPSY lane. It does not materialize
    DataLad content or inspect declared artifact files in this phase.
 
    If the MKRF submodule is thin or missing annexed content, run the

--- a/docs/operator-runbook.rst
+++ b/docs/operator-runbook.rst
@@ -4,19 +4,25 @@
 Minimal Operator Path
 ---------------------
 
-1. Validate and plan the FreshForge workflow graph:
+1. Discover and render the FreshForge workflow commands from the parent FEMIC
+   checkout:
+
+   - ``python -m femic freshforge workflows list``
+   - ``python -m femic freshforge workflows commands external/femic-mkrf-instance/workflows/freshforge/mkrf_model_build_workflow.yaml``
+
+2. Validate and plan the FreshForge workflow graph:
 
    - ``freshforge providers``
-   - ``freshforge validate workflows/freshforge/mkrf_model_build_workflow.yaml``
-   - ``freshforge inspect workflows/freshforge/mkrf_model_build_workflow.yaml``
-   - ``freshforge plan workflows/freshforge/mkrf_model_build_workflow.yaml``
+   - ``freshforge validate external/femic-mkrf-instance/workflows/freshforge/mkrf_model_build_workflow.yaml``
+   - ``freshforge inspect external/femic-mkrf-instance/workflows/freshforge/mkrf_model_build_workflow.yaml``
+   - ``freshforge plan external/femic-mkrf-instance/workflows/freshforge/mkrf_model_build_workflow.yaml``
 
    These commands are non-mutating graph checks.
 
-2. Run the FreshForge workflow only when the local environment is ready for
+3. Run the FreshForge workflow only when the local environment is ready for
    FEMIC, BTC, and Patchworks:
 
-   - ``freshforge run workflows/freshforge/mkrf_model_build_workflow.yaml --workdir runtime/freshforge --namespace mkrf/model-build --json``
+   - ``freshforge run external/femic-mkrf-instance/workflows/freshforge/mkrf_model_build_workflow.yaml --workdir runtime/freshforge --namespace mkrf/model-build --json``
 
    ``freshforge run`` launches provider-owned FEMIC commands in planned order.
    The current executable graph uses the MKRF-owned runtime-package
@@ -36,21 +42,21 @@ Minimal Operator Path
    ``freshforge run`` performs real submodule, package-install, DataLad, and
    git-annex work.
 
-3. Validate the instance spec:
+4. Validate the instance spec as a separate pre-run FEMIC check:
 
-   - ``femic instance validate-spec --spec config/rebuild.spec.yaml``
+   - ``python -m femic instance validate-spec --instance-root external/femic-mkrf-instance --spec config/rebuild.spec.yaml``
 
-4. Review the current runtime wiring:
+5. Review the current runtime wiring:
 
    - ``config/patchworks.runtime.mkrf_rebuild.windows.yaml``
 
-5. Inspect or launch the canonical runtime package from:
+6. Inspect or launch the canonical runtime package from:
 
    - runtime XML: ``models/mkrf_patchworks_model/xml/forestmodel.xml``
    - runtime tracks: ``models/mkrf_patchworks_model/tracks/``
    - runtime spatial: ``models/mkrf_patchworks_model/spatial/``
 
-6. Use the canonical package for:
+7. Use the canonical package for:
 
    - current runtime/package inspection;
    - Matrix Builder rebuild validation; and

--- a/docs/rebuild-and-qa.rst
+++ b/docs/rebuild-and-qa.rst
@@ -19,11 +19,13 @@ is no longer the primary meaning of MKRF rebuild/QA in this instance.
 Core Validation Surfaces
 ------------------------
 
-- ``femic instance validate-spec --spec config/rebuild.spec.yaml``
-- ``freshforge validate workflows/freshforge/mkrf_model_build_workflow.yaml``
-- ``freshforge inspect workflows/freshforge/mkrf_model_build_workflow.yaml``
-- ``freshforge plan workflows/freshforge/mkrf_model_build_workflow.yaml``
-- ``freshforge run workflows/freshforge/mkrf_model_build_workflow.yaml --workdir runtime/freshforge --namespace mkrf/model-build --json``
+- ``python -m femic instance validate-spec --instance-root external/femic-mkrf-instance --spec config/rebuild.spec.yaml``
+- ``python -m femic freshforge workflows list``
+- ``python -m femic freshforge workflows commands external/femic-mkrf-instance/workflows/freshforge/mkrf_model_build_workflow.yaml``
+- ``freshforge validate external/femic-mkrf-instance/workflows/freshforge/mkrf_model_build_workflow.yaml``
+- ``freshforge inspect external/femic-mkrf-instance/workflows/freshforge/mkrf_model_build_workflow.yaml``
+- ``freshforge plan external/femic-mkrf-instance/workflows/freshforge/mkrf_model_build_workflow.yaml``
+- ``freshforge run external/femic-mkrf-instance/workflows/freshforge/mkrf_model_build_workflow.yaml --workdir runtime/freshforge --namespace mkrf/model-build --json``
 - ``freshforge validate external/femic-mkrf-instance/workflows/freshforge/mkrf_materialization_workflow.yaml``
 - ``freshforge inspect external/femic-mkrf-instance/workflows/freshforge/mkrf_materialization_workflow.yaml``
 - ``freshforge plan external/femic-mkrf-instance/workflows/freshforge/mkrf_materialization_workflow.yaml``
@@ -57,7 +59,8 @@ FreshForge Workflow Boundary
 
 The FreshForge workflow at
 ``workflows/freshforge/mkrf_model_build_workflow.yaml`` is the declarative
-contract for the MKRF rebuild graph. It records the validate-case through
+contract for the MKRF rebuild graph. From the parent FEMIC checkout, it records
+the validate-case through
 matrix-build order, reusable FEMIC provider references, MKRF-owned provider
 references, MKRF-owned configuration paths, and declared runtime artifacts.
 
@@ -72,6 +75,8 @@ older TSA-style ``femic run`` and BTC/post-TIPSY nodes because those still
 require legacy checkpoint files outside the accepted MKRF source contract.
 ``femic instance rebuild --dry-run`` remains the legacy execution dry-run
 comparison surface for ``config/rebuild.spec.yaml``.
+Run rebuild-spec validation separately before FreshForge execution with
+``python -m femic instance validate-spec --instance-root external/femic-mkrf-instance --spec config/rebuild.spec.yaml``.
 
 Install this repository's adapter package before running FreshForge commands:
 

--- a/docs/rebuild-and-qa.rst
+++ b/docs/rebuild-and-qa.rst
@@ -60,19 +60,21 @@ FreshForge Workflow Boundary
 The FreshForge workflow at
 ``workflows/freshforge/mkrf_model_build_workflow.yaml`` is the declarative
 contract for the MKRF rebuild graph. From the parent FEMIC checkout, it records
-the validate-case through
-matrix-build order, reusable FEMIC provider references, MKRF-owned provider
-references, MKRF-owned configuration paths, and declared runtime artifacts.
+the MKRF runtime-package regeneration through matrix-build order, reusable
+FEMIC provider references, MKRF-owned provider references, MKRF-owned
+configuration paths, and declared runtime artifacts.
 
 FreshForge validation, inspection, and planning are non-mutating. FreshForge
 ``run`` explicitly launches provider-owned FEMIC commands in planned order,
 including the MKRF-owned runtime-package regeneration commands and Patchworks
-Matrix Builder. FreshForge materialization is a separate workflow that can
+Matrix Builder. The executable graph starts with the MKRF-owned provider nodes
+because older TSA-style case/geospatial preflight surfaces still require legacy
+checkpoint files outside the accepted MKRF source contract. FreshForge
+materialization is a separate workflow that can
 prepare a thin parent checkout by initializing the MKRF submodule, installing
 dependencies, enabling ``arbutus-s3``, materializing required MKRF paths, and
 writing an ignored report. The current MKRF executable graph does not use the
-older TSA-style ``femic run`` and BTC/post-TIPSY nodes because those still
-require legacy checkpoint files outside the accepted MKRF source contract.
+older TSA-style ``femic run`` and BTC/post-TIPSY nodes.
 ``femic instance rebuild --dry-run`` remains the legacy execution dry-run
 comparison surface for ``config/rebuild.spec.yaml``.
 Run rebuild-spec validation separately before FreshForge execution with

--- a/planning/freshforge_executable_model_build.md
+++ b/planning/freshforge_executable_model_build.md
@@ -1,0 +1,22 @@
+# MKRF FreshForge Executable Model-Build Acceptance
+
+This note records the MKRF-side work for FEMIC P106.
+
+The MKRF instance owns the executable workflow and the `mkrf.*` provider
+namespace. FEMIC core supplies reusable `femic.*` stages such as case
+validation, geospatial preflight, Patchworks preflight, and Matrix Builder.
+
+P106 updates the MKRF adapter to the released FreshForge execution API:
+`run_node(...)` returns `ProviderRunResult` with `RunStatus`, deterministic
+command metadata, diagnostics, outputs, and JSON-safe artifacts. The adapter
+continues to launch instance-owned `python -m mkrf_femic ...` commands rather
+than moving MKRF workflow code into FEMIC core.
+
+The model-build workflow runs from the parent FEMIC checkout. Its
+`instance_root` parameters should be `external/femic-mkrf-instance`; all other
+workflow paths remain instance-relative unless they are intentionally
+parent-owned FreshForge runtime paths.
+
+Materialization remains a prerequisite workflow. If the MKRF submodule is thin
+or incomplete, run the MKRF materialization workflow before the model-build
+workflow.

--- a/runbooks/REBUILD_RUNBOOK.md
+++ b/runbooks/REBUILD_RUNBOOK.md
@@ -11,7 +11,7 @@ companion to that docs surface, not as a replacement for it.
 
 ## Thin-baseline checks
 
-1. `femic instance validate-spec --spec config/rebuild.spec.yaml`
+1. `python -m femic instance validate-spec --instance-root external/femic-mkrf-instance --spec config/rebuild.spec.yaml`
 2. `femic instance rebuild --spec config/rebuild.spec.yaml --dry-run --run-id mkrf_dryrun`
 
 ## FreshForge workflow checks and execution
@@ -21,18 +21,23 @@ The instance-owned FreshForge graph is:
 - `workflows/freshforge/mkrf_model_build_workflow.yaml`
 - `workflows/freshforge/mkrf_materialization_workflow.yaml`
 
+From the parent FEMIC checkout, use workflow discovery to find and render the
+model-build commands:
+
+1. `python -m femic freshforge workflows list`
+2. `python -m femic freshforge workflows commands external/femic-mkrf-instance/workflows/freshforge/mkrf_model_build_workflow.yaml`
+
 Use it to validate, inspect, and plan the rebuild graph before execution:
 
-1. `python -m pip install -e .`
-2. `freshforge providers`
-3. `freshforge validate workflows/freshforge/mkrf_model_build_workflow.yaml`
-4. `freshforge inspect workflows/freshforge/mkrf_model_build_workflow.yaml`
-5. `freshforge plan workflows/freshforge/mkrf_model_build_workflow.yaml`
+3. `freshforge providers`
+4. `freshforge validate external/femic-mkrf-instance/workflows/freshforge/mkrf_model_build_workflow.yaml`
+5. `freshforge inspect external/femic-mkrf-instance/workflows/freshforge/mkrf_model_build_workflow.yaml`
+6. `freshforge plan external/femic-mkrf-instance/workflows/freshforge/mkrf_model_build_workflow.yaml`
 
 Run it explicitly only when the local environment is ready for FEMIC, BTC, and
 Patchworks:
 
-6. `freshforge run workflows/freshforge/mkrf_model_build_workflow.yaml --workdir runtime/freshforge --namespace mkrf/model-build --json`
+7. `freshforge run external/femic-mkrf-instance/workflows/freshforge/mkrf_model_build_workflow.yaml --workdir runtime/freshforge --namespace mkrf/model-build --json`
 
 FreshForge `validate`, `inspect`, and `plan` are non-mutating. FreshForge `run`
 launches provider-owned FEMIC commands in planned order. The current executable

--- a/runbooks/REBUILD_RUNBOOK.md
+++ b/runbooks/REBUILD_RUNBOOK.md
@@ -40,9 +40,9 @@ Patchworks:
 7. `freshforge run external/femic-mkrf-instance/workflows/freshforge/mkrf_model_build_workflow.yaml --workdir runtime/freshforge --namespace mkrf/model-build --json`
 
 FreshForge `validate`, `inspect`, and `plan` are non-mutating. FreshForge `run`
-launches provider-owned FEMIC commands in planned order. The current executable
-graph uses the MKRF-owned runtime-package regeneration commands after
-geospatial preflight; older TSA-style `femic run` and BTC/post-TIPSY nodes still
+launches provider-owned commands in planned order. The current executable graph
+starts with the MKRF-owned runtime-package regeneration commands; older
+TSA-style case/geospatial preflight, `femic run`, and BTC/post-TIPSY nodes still
 require legacy checkpoint files outside the accepted MKRF source contract. It
 does not materialize DataLad content; use the materialization workflow first
 from the parent checkout when starting from a thin clone.

--- a/src/mkrf_freshforge/__init__.py
+++ b/src/mkrf_freshforge/__init__.py
@@ -12,6 +12,7 @@ import subprocess
 import sys
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 
 PROVIDER_ID = "mkrf"
@@ -271,7 +272,7 @@ def _execute_with_builder(
                     ),
                     location=f"nodes.{node.id}",
                 ),
-            )
+            ),
         )
     try:
         command = builder(node, context)
@@ -285,13 +286,16 @@ def _execute_with_builder(
                     message=str(exc),
                     location=f"nodes.{node.id}.parameters",
                 ),
-            )
+            ),
         )
-    completed = runner(command)
+    cwd = _execution_cwd(node)
+    completed = _run_command(runner, command, cwd=cwd)
     data: dict[str, Any] = {
         "command": list(command),
         "returncode": completed.returncode,
     }
+    if cwd is not None:
+        data["cwd"] = str(cwd)
     if completed.stdout:
         data["stdout"] = completed.stdout
     if completed.stderr:
@@ -334,14 +338,28 @@ def _resolved_artifacts(node: Any, context: Any) -> dict[str, Any]:
     return resolved
 
 
+def _run_command(
+    runner: CommandRunner,
+    command: tuple[str, ...],
+    *,
+    cwd: Path | None,
+) -> subprocess.CompletedProcess[str]:
+    if runner is _default_command_runner:
+        return _default_command_runner(command, cwd=cwd)
+    return runner(command)
+
+
 def _default_command_runner(
     command: tuple[str, ...],
+    *,
+    cwd: Path | None = None,
 ) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         list(command),
         check=False,
         capture_output=True,
         text=True,
+        cwd=cwd,
     )
 
 
@@ -369,6 +387,19 @@ def _optional_parameter(node: Any, key: str) -> str | None:
     return str(value)
 
 
+def _execution_cwd(node: Any) -> Path | None:
+    instance_root = _optional_parameter(node, "instance_root")
+    if instance_root is None:
+        return None
+    return Path(instance_root)
+
+
+def _execution_instance_root(node: Any) -> str:
+    return (
+        "." if _execution_cwd(node) is not None else _parameter(node, "instance_root")
+    )
+
+
 def _append_option(command: list[str], node: Any, key: str, option: str) -> None:
     value = _optional_parameter(node, key)
     if value is not None:
@@ -390,7 +421,7 @@ def _build_au_inputs_command(node: Any, _context: Any) -> tuple[str, ...]:
         _python_m_mkrf_femic(
             "mkrf-build-au-inputs",
             "--instance-root",
-            _parameter(node, "instance_root"),
+            _execution_instance_root(node),
             "--resultant-gdb",
             _parameter(node, "resultant_gdb"),
         )
@@ -404,7 +435,7 @@ def _build_select_aus_command(node: Any, _context: Any) -> tuple[str, ...]:
         _python_m_mkrf_femic(
             "mkrf-select-aus",
             "--instance-root",
-            _parameter(node, "instance_root"),
+            _execution_instance_root(node),
         )
     )
     _append_option(command, node, "au_table_csv", "--au-table-csv")
@@ -419,7 +450,7 @@ def _build_managed_au_inputs_command(node: Any, _context: Any) -> tuple[str, ...
         _python_m_mkrf_femic(
             "mkrf-build-managed-au-inputs",
             "--instance-root",
-            _parameter(node, "instance_root"),
+            _execution_instance_root(node),
             "--resultant-gdb",
             _parameter(node, "resultant_gdb"),
         )
@@ -436,7 +467,7 @@ def _build_managed_au_curves_command(node: Any, _context: Any) -> tuple[str, ...
         _python_m_mkrf_femic(
             "mkrf-build-managed-au-curves",
             "--instance-root",
-            _parameter(node, "instance_root"),
+            _execution_instance_root(node),
             "--run-id",
             _parameter(node, "run_id"),
         )
@@ -454,7 +485,7 @@ def _build_init_runtime_package_command(node: Any, _context: Any) -> tuple[str, 
         _python_m_mkrf_femic(
             "mkrf-init-runtime-package",
             "--instance-root",
-            _parameter(node, "instance_root"),
+            _execution_instance_root(node),
         )
     )
     _append_option(command, node, "package_root", "--package-root")

--- a/src/mkrf_freshforge/__init__.py
+++ b/src/mkrf_freshforge/__init__.py
@@ -105,7 +105,15 @@ class MkrfFreshForgeProvider:
         return _validate_contract_node(node, node_type, location=location)
 
     def execute_node(self, node: Any, node_type: Any, *, context: Any) -> Any:
-        """Execute one MKRF node through the installed FEMIC CLI."""
+        """Execute one MKRF node through the installed FEMIC CLI.
+
+        This compatibility shim supports callers that used the pre-release
+        FreshForge execution hook. Released FreshForge calls :meth:`run_node`.
+        """
+        return self.run_node(node, node_type, context=context)
+
+    def run_node(self, node: Any, node_type: Any, *, context: Any) -> Any:
+        """Execute one MKRF node through the released FreshForge API."""
         return _execute_with_builder(
             node=node,
             node_type=node_type,
@@ -229,14 +237,14 @@ def _freshforge_diagnostic_types() -> tuple[Any, Any]:
     return Diagnostic, DiagnosticSeverity
 
 
-def _freshforge_execution_result_type() -> Any:
+def _freshforge_run_result_types() -> tuple[Any, Any]:
     try:
-        from freshforge.records import ProviderExecutionResult
+        from freshforge.records import ProviderRunResult, RunStatus
     except ModuleNotFoundError as exc:
         raise RuntimeError(
             "The MKRF FreshForge adapter requires FreshForge to be installed."
         ) from exc
-    return ProviderExecutionResult
+    return ProviderRunResult, RunStatus
 
 
 def _execute_with_builder(
@@ -247,12 +255,12 @@ def _execute_with_builder(
     builders: dict[str, Callable[[Any, Any], tuple[str, ...]]],
     runner: CommandRunner,
 ) -> Any:
-    _ = context
-    result_type = _freshforge_execution_result_type()
+    result_type, run_status = _freshforge_run_result_types()
     diagnostic, severity = _freshforge_diagnostic_types()
     builder = builders.get(str(node_type.id))
     if builder is None:
         return result_type(
+            status=run_status.FAILED,
             diagnostics=(
                 diagnostic(
                     severity=severity.ERROR,
@@ -269,6 +277,7 @@ def _execute_with_builder(
         command = builder(node, context)
     except ValueError as exc:
         return result_type(
+            status=run_status.FAILED,
             diagnostics=(
                 diagnostic(
                     severity=severity.ERROR,
@@ -279,11 +288,14 @@ def _execute_with_builder(
             )
         )
     completed = runner(command)
-    metadata: dict[str, Any] = {"returncode": completed.returncode}
+    data: dict[str, Any] = {
+        "command": list(command),
+        "returncode": completed.returncode,
+    }
     if completed.stdout:
-        metadata["stdout"] = completed.stdout
+        data["stdout"] = completed.stdout
     if completed.stderr:
-        metadata["stderr"] = completed.stderr
+        data["stderr"] = completed.stderr
     diagnostics: tuple[Any, ...] = ()
     if completed.returncode != 0:
         diagnostics = (
@@ -297,13 +309,29 @@ def _execute_with_builder(
                 location=f"nodes.{node.id}",
             ),
         )
-    artifacts = node.artifacts if isinstance(node.artifacts, dict) else {}
+    artifacts = _resolved_artifacts(node, context)
+    outputs = node.outputs if isinstance(node.outputs, dict) else {}
     return result_type(
-        metadata=metadata,
-        command=command,
+        status=run_status.SUCCESS if completed.returncode == 0 else run_status.FAILED,
+        outputs=outputs,
         diagnostics=diagnostics,
         artifacts=artifacts,
+        data=data,
     )
+
+
+def _resolved_artifacts(node: Any, context: Any) -> dict[str, Any]:
+    artifacts = node.artifacts if isinstance(node.artifacts, dict) else {}
+    resolve_path = getattr(context, "resolve_path", None)
+    if not callable(resolve_path):
+        return dict(artifacts)
+    resolved: dict[str, Any] = {}
+    for key, value in artifacts.items():
+        if isinstance(value, str):
+            resolved[key] = str(resolve_path(value))
+        else:
+            resolved[key] = value
+    return resolved
 
 
 def _default_command_runner(

--- a/tests/test_mkrf_freshforge.py
+++ b/tests/test_mkrf_freshforge.py
@@ -72,8 +72,9 @@ def test_pyproject_declares_mkrf_freshforge_entry_point() -> None:
     assert entry_points["mkrf"] == "mkrf_freshforge:provider_factory"
 
 
-def test_provider_execution_constructs_mkrf_femic_command() -> None:
-    from freshforge.records import ExecutionContext, WorkflowNode
+def test_provider_run_constructs_mkrf_femic_command() -> None:
+    from freshforge.execution import RunContext
+    from freshforge.records import RunStatus, WorkflowNode
 
     commands: list[tuple[str, ...]] = []
     provider = MkrfFreshForgeProvider(command_runner=_successful_runner(commands))
@@ -89,13 +90,24 @@ def test_provider_execution_constructs_mkrf_femic_command() -> None:
         },
     )
 
-    result = provider.execute_node(
+    result = provider.run_node(
         node,
         node_type,
-        context=ExecutionContext(workflow_id="wf", run_id="run"),
+        context=RunContext(workflow_id="wf", workdir=Path("runtime/freshforge")),
     )
 
+    assert result.status == RunStatus.SUCCESS
     assert result.diagnostics == ()
+    assert result.data["command"] == [
+        sys.executable,
+        "-m",
+        "mkrf_femic",
+        "mkrf-build-au-inputs",
+        "--instance-root",
+        ".",
+        "--resultant-gdb",
+        "data/source/03_MappingAnalysisData/Resultant.gdb",
+    ]
     assert commands == [
         (
             sys.executable,
@@ -133,21 +145,30 @@ def test_workflow_validates_and_plans_with_mkrf_provider() -> None:
     assert {node.provider_id for node in plan.nodes} == {"femic", "mkrf"}
 
 
-def test_workflow_dry_run_uses_mkrf_provider() -> None:
-    from freshforge.execution import execute_workflow
+def test_workflow_run_uses_mkrf_provider_with_mocked_commands() -> None:
+    from femic.freshforge import FemicFreshForgeProvider
+    from freshforge.execution import run_workflow
     from freshforge.loading import load_workflow
+    from freshforge.providers import ProviderRegistry
+    from freshforge.records import RunStatus
 
     spec, load_diagnostics = load_workflow(WORKFLOW_PATH)
     assert spec is not None
 
-    report = execute_workflow(
+    commands: list[tuple[str, ...]] = []
+    registry = ProviderRegistry()
+    registry.register(FemicFreshForgeProvider(command_runner=_successful_runner(commands)))
+    registry.register(MkrfFreshForgeProvider(command_runner=_successful_runner(commands)))
+
+    report = run_workflow(
         spec,
-        run_id="mkrf_freshforge_exec",
         diagnostics=load_diagnostics,
-        registry=_registry_with_femic_and_mkrf(),
-        dry_run=True,
+        registry=registry,
+        workdir="runtime/freshforge",
+        run_namespace="mkrf/model-build",
     )
 
-    assert not report.failed
-    assert report.dry_run
-    assert report.planned_order == tuple(EXPECTED_MODEL_BUILD_ORDER)
+    assert report.status == RunStatus.SUCCESS
+    assert [node.id for node in report.nodes] == EXPECTED_MODEL_BUILD_ORDER
+    assert commands
+    assert any(command[:3] == (sys.executable, "-m", "mkrf_femic") for command in commands)

--- a/tests/test_mkrf_freshforge.py
+++ b/tests/test_mkrf_freshforge.py
@@ -13,8 +13,6 @@ freshforge = pytest.importorskip("freshforge")
 
 WORKFLOW_PATH = Path("workflows/freshforge/mkrf_model_build_workflow.yaml")
 EXPECTED_MODEL_BUILD_ORDER = [
-    "validate_case",
-    "geospatial_preflight",
     "build_au_inputs",
     "select_aus",
     "build_managed_au_inputs",
@@ -157,8 +155,12 @@ def test_workflow_run_uses_mkrf_provider_with_mocked_commands() -> None:
 
     commands: list[tuple[str, ...]] = []
     registry = ProviderRegistry()
-    registry.register(FemicFreshForgeProvider(command_runner=_successful_runner(commands)))
-    registry.register(MkrfFreshForgeProvider(command_runner=_successful_runner(commands)))
+    registry.register(
+        FemicFreshForgeProvider(command_runner=_successful_runner(commands))
+    )
+    registry.register(
+        MkrfFreshForgeProvider(command_runner=_successful_runner(commands))
+    )
 
     report = run_workflow(
         spec,
@@ -171,4 +173,6 @@ def test_workflow_run_uses_mkrf_provider_with_mocked_commands() -> None:
     assert report.status == RunStatus.SUCCESS
     assert [node.id for node in report.nodes] == EXPECTED_MODEL_BUILD_ORDER
     assert commands
-    assert any(command[:3] == (sys.executable, "-m", "mkrf_femic") for command in commands)
+    assert any(
+        command[:3] == (sys.executable, "-m", "mkrf_femic") for command in commands
+    )

--- a/workflows/freshforge/mkrf_model_build_workflow.yaml
+++ b/workflows/freshforge/mkrf_model_build_workflow.yaml
@@ -3,30 +3,8 @@ workflow:
   name: MKRF FEMIC executable model-build workflow
   description: Explicit FreshForge execution graph for the MKRF canonical rebuild lane.
 nodes:
-  - id: validate_case
-    provider: femic.validate_case
-    outputs:
-      case_validation: case_preflight_ok
-    parameters:
-      instance_root: external/femic-mkrf-instance
-      run_config: config/run_profile.mkrf.yaml
-      tipsy_config_dir: config/tipsy
-  - id: geospatial_preflight
-    provider: femic.geospatial_preflight
-    needs:
-      - validate_case
-    inputs:
-      case_validation: validate_case.case_validation
-    outputs:
-      geospatial_runtime: geospatial_runtime_ok
-    parameters:
-      instance_root: external/femic-mkrf-instance
   - id: build_au_inputs
     provider: mkrf.build_au_inputs
-    needs:
-      - geospatial_preflight
-    inputs:
-      geospatial_runtime: geospatial_preflight.geospatial_runtime
     outputs:
       au_inputs: data/model_input_bundle
     parameters:

--- a/workflows/freshforge/mkrf_model_build_workflow.yaml
+++ b/workflows/freshforge/mkrf_model_build_workflow.yaml
@@ -8,9 +8,8 @@ nodes:
     outputs:
       case_validation: case_preflight_ok
     parameters:
-      instance_root: .
+      instance_root: external/femic-mkrf-instance
       run_config: config/run_profile.mkrf.yaml
-      rebuild_spec: config/rebuild.spec.yaml
       tipsy_config_dir: config/tipsy
   - id: geospatial_preflight
     provider: femic.geospatial_preflight
@@ -21,7 +20,7 @@ nodes:
     outputs:
       geospatial_runtime: geospatial_runtime_ok
     parameters:
-      instance_root: .
+      instance_root: external/femic-mkrf-instance
   - id: build_au_inputs
     provider: mkrf.build_au_inputs
     needs:
@@ -31,7 +30,7 @@ nodes:
     outputs:
       au_inputs: data/model_input_bundle
     parameters:
-      instance_root: .
+      instance_root: external/femic-mkrf-instance
       resultant_gdb: data/source/03_MappingAnalysisData/Resultant.gdb
       output_dir: data/model_input_bundle
     artifacts:
@@ -46,7 +45,7 @@ nodes:
     outputs:
       selected_aus: data/model_input_bundle/selected_au_table.csv
     parameters:
-      instance_root: .
+      instance_root: external/femic-mkrf-instance
       au_table_csv: data/model_input_bundle/au_table.csv
       assignment_csv: data/model_input_bundle/stand_au_assignment.csv
       output_csv: data/model_input_bundle/selected_au_table.csv
@@ -62,7 +61,7 @@ nodes:
     outputs:
       managed_au_inputs: data/model_input_bundle
     parameters:
-      instance_root: .
+      instance_root: external/femic-mkrf-instance
       resultant_gdb: data/source/03_MappingAnalysisData/Resultant.gdb
       tipsy_rules_yaml: config/tipsy/tsamkrf.yaml
       selected_au_csv: data/model_input_bundle/selected_au_table.csv
@@ -80,7 +79,7 @@ nodes:
     outputs:
       managed_au_curves: data/model_input_bundle/managed_au_curves.csv
     parameters:
-      instance_root: .
+      instance_root: external/femic-mkrf-instance
       run_id: mkrf_freshforge_exec
       bootstrap_csv: data/model_input_bundle/managed_au_bootstrap_table.csv
       msyt_csv: data/model_input_bundle/managed_au_msyt.csv
@@ -98,7 +97,7 @@ nodes:
     outputs:
       patchworks_package: models/mkrf_patchworks_model
     parameters:
-      instance_root: .
+      instance_root: external/femic-mkrf-instance
       package_root: models/mkrf_patchworks_model
       selected_au_csv: data/model_input_bundle/selected_au_table.csv
       stand_origin_assignment_csv: data/model_input_bundle/stand_origin_assignment.csv
@@ -123,7 +122,7 @@ nodes:
     outputs:
       patchworks_runtime: patchworks_runtime_ok
     parameters:
-      instance_root: .
+      instance_root: external/femic-mkrf-instance
       patchworks_config: config/patchworks.runtime.mkrf_rebuild.windows.yaml
   - id: matrix_build
     provider: femic.matrix_build
@@ -134,7 +133,7 @@ nodes:
     outputs:
       compiled_patchworks_model: models/mkrf_patchworks_model/tracks
     parameters:
-      instance_root: .
+      instance_root: external/femic-mkrf-instance
       patchworks_config: config/patchworks.runtime.mkrf_rebuild.windows.yaml
       run_id: mkrf_freshforge_exec
       log_dir: runtime/logs


### PR DESCRIPTION
## Summary

Implements MKRF executable FreshForge model-build acceptance for parent-checkout execution.

This PR:

- updates the MKRF FreshForge adapter to the released `run_node(...)` / `ProviderRunResult` API while keeping an `execute_node(...)` compatibility shim;
- keeps MKRF-specific execution inside the instance-owned `mkrf.*` provider namespace;
- updates the MKRF model-build workflow so the executable graph starts with MKRF-owned runtime-package regeneration nodes and then runs generic FEMIC Patchworks preflight / Matrix Builder nodes;
- documents the released FreshForge CLI command shape and the materialization prerequisite;
- fixes parent-checkout execution so `mkrf_femic` commands run with `cwd` set to the instance root and receive `--instance-root .`, preserving instance-relative tracked metadata.

Closes #50.

## Validation

- `python -m pytest tests/test_mkrf_freshforge.py -q`
- `python -m ruff check src tests`
- `python -m sphinx -b html docs _build/html -W`
- parent-checkout `freshforge validate/inspect/plan external/femic-mkrf-instance/workflows/freshforge/mkrf_model_build_workflow.yaml --json`
- parent-checkout `freshforge run external/femic-mkrf-instance/workflows/freshforge/mkrf_model_build_workflow.yaml --workdir runtime/freshforge --namespace mkrf/model-build --json`
- `git annex find --not --in arbutus-s3 -- models data/source`

Runtime acceptance:

- Matrix Builder manifest for `mkrf_freshforge_exec` reported `returncode=0`;
- Matrix Builder stderr ended with `Done Matrix Builder.`;
- `forestmodel.xml`, `fragments.dbf`, and compiled tracks exist;
- compiled tracks contain 98,413 `features.csv` rows, 62 `protoaccounts.csv` rows, 62 `accounts.csv` rows, 2,684,869 `curves.csv` rows, and 140,196 `products.csv` rows.
